### PR TITLE
Fix issues #10-#14

### DIFF
--- a/inc/Abilities/ProjectAbilities.php
+++ b/inc/Abilities/ProjectAbilities.php
@@ -62,7 +62,7 @@ class ProjectAbilities {
 										'name' => [ 'type' => 'string' ],
 										'slug' => [ 'type' => 'string' ],
 										'project_type' => [
-											'type' => 'object',
+											'type' => [ 'object', 'null' ],
 											'properties' => [
 												'id' => [ 'type' => 'integer' ],
 												'name' => [ 'type' => 'string' ],
@@ -81,7 +81,7 @@ class ProjectAbilities {
 				],
 			],
 			'execute_callback'    => [ self::class, 'get_projects' ],
-			'permission_callback' => fn() => current_user_can( 'edit_posts' ),
+			'permission_callback' => '__return_true',
 			'meta'                => [ 'show_in_rest' => true ],
 		] );
 
@@ -135,7 +135,7 @@ class ProjectAbilities {
 				],
 			],
 			'execute_callback'    => [ self::class, 'get_project_types' ],
-			'permission_callback' => fn() => current_user_can( 'edit_posts' ),
+			'permission_callback' => '__return_true',
 			'meta'                => [ 'show_in_rest' => true ],
 		] );
 	}

--- a/inc/Abilities/SearchAbilities.php
+++ b/inc/Abilities/SearchAbilities.php
@@ -54,7 +54,15 @@ class SearchAbilities {
 								'excerpt'  => [ 'type' => 'string' ],
 								'link'     => [ 'type' => 'string' ],
 								'project' => [
-									'type'       => 'object',
+									'type'       => [ 'object', 'null' ],
+									'properties' => [
+										'id'   => [ 'type' => 'integer' ],
+										'name' => [ 'type' => 'string' ],
+										'slug' => [ 'type' => 'string' ],
+									],
+								],
+								'project_type' => [
+									'type'       => [ 'object', 'null' ],
 									'properties' => [
 										'id'   => [ 'type' => 'integer' ],
 										'name' => [ 'type' => 'string' ],
@@ -122,12 +130,35 @@ class SearchAbilities {
 				];
 			}
 
+			$project_type_data = null;
+			if ( $project_term ) {
+				$type_slug = Project::get_project_type( $project_term );
+				if ( $type_slug ) {
+					$type_term = get_term_by( 'slug', $type_slug, 'project_type' );
+					if ( $type_term && ! is_wp_error( $type_term ) ) {
+						$project_type_data = [
+							'id'   => $type_term->term_id,
+							'name' => $type_term->name,
+							'slug' => $type_term->slug,
+						];
+					}
+				}
+			}
+
+			$excerpt = get_the_excerpt( $post );
+			if ( empty( $excerpt ) && ! empty( $post->post_content ) ) {
+				$excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 30, '...' );
+			} else {
+				$excerpt = wp_trim_words( $excerpt, 20, '...' );
+			}
+
 			$items[] = [
-				'id'      => $post->ID,
-				'title'   => get_the_title( $post ),
-				'excerpt' => wp_trim_words( get_the_excerpt( $post ), 20, '...' ),
-				'link'    => get_permalink( $post ),
-				'project' => $project_data,
+				'id'           => $post->ID,
+				'title'        => get_the_title( $post ),
+				'excerpt'      => $excerpt,
+				'link'         => get_permalink( $post ),
+				'project'      => $project_data,
+				'project_type' => $project_type_data,
 			];
 		}
 

--- a/inc/Api/Controllers/DocsController.php
+++ b/inc/Api/Controllers/DocsController.php
@@ -219,7 +219,7 @@ class DocsController {
                 'assigned_term'  => null,
                 'project'        => null,
                 'category'       => null,
-                'project_type'   => '',
+                'project_type'   => null,
                 'hierarchy_path' => '',
             ];
         }
@@ -227,6 +227,21 @@ class DocsController {
         $primary = Project::get_primary_term($terms);
         $project = Project::get_project_term($terms);
         $category = Project::get_top_level_term($terms);
+
+        $project_type_data = null;
+        if ( $project ) {
+            $type_slug = Project::get_project_type( $project );
+            if ( $type_slug ) {
+                $type_term = get_term_by( 'slug', $type_slug, 'project_type' );
+                if ( $type_term && ! is_wp_error( $type_term ) ) {
+                    $project_type_data = [
+                        'id'   => $type_term->term_id,
+                        'name' => $type_term->name,
+                        'slug' => $type_term->slug,
+                    ];
+                }
+            }
+        }
 
         return [
             'assigned_term'  => $primary ? [
@@ -244,7 +259,7 @@ class DocsController {
                 'slug' => $category->slug,
                 'name' => $category->name,
             ] : null,
-            'project_type'   => $primary ? Project::get_project_type($primary) : '',
+            'project_type'   => $project_type_data,
             'hierarchy_path' => Project::build_term_hierarchy_path($terms),
         ];
     }

--- a/inc/Api/Controllers/ProjectController.php
+++ b/inc/Api/Controllers/ProjectController.php
@@ -111,7 +111,18 @@ class ProjectController {
 	private static function prepare_term( \WP_Term $term, bool $include_repo_info = false ): array {
 		$top_level    = Project::get_top_level_term( $term );
 		$project      = Project::get_project_term( $term );
-		$project_type = Project::get_term_depth( $term ) === 1 ? Project::get_project_type_from_meta( $term ) : null;
+		$project_type_slug = Project::get_project_type( $term );
+		$project_type_data = null;
+		if ( $project_type_slug ) {
+			$type_term = get_term_by( 'slug', $project_type_slug, 'project_type' );
+			if ( $type_term && ! is_wp_error( $type_term ) ) {
+				$project_type_data = [
+					'id'   => $type_term->term_id,
+					'name' => $type_term->name,
+					'slug' => $type_term->slug,
+				];
+			}
+		}
 
 		$item = array(
 			'id'           => $term->term_id,
@@ -120,7 +131,7 @@ class ProjectController {
 			'description'  => $term->description,
 			'parent'       => $term->parent,
 			'count'        => $term->count,
-			'project_type' => $project_type,
+			'project_type' => $project_type_data,
 			'is_top_level' => Project::is_top_level_term( $term ),
 			'is_project'   => $project && $project->term_id === $term->term_id,
 		);

--- a/inc/Sync/SyncManager.php
+++ b/inc/Sync/SyncManager.php
@@ -29,6 +29,11 @@ class SyncManager {
 		$processor = new MarkdownProcessor( $project_slug, $source_file, $project_term_id );
 		$content   = $processor->process( $content );
 
+		// Auto-generate excerpt if empty
+		if ( empty( $excerpt ) && ! empty( $content ) ) {
+			$excerpt = wp_trim_words( wp_strip_all_tags( $content ), 30, '...' );
+		}
+
 		$leaf_term_id = self::resolve_subpath( $project_term_id, $subpath );
 		if ( is_wp_error( $leaf_term_id ) ) {
 			return [


### PR DESCRIPTION
Fixes #10, #11, #12, #13, #14

- **#10**: Make get-projects and get-project-types abilities publicly accessible (`__return_true`)
- **#11**: Fix project tree REST endpoint — replaced undefined `get_project_type_from_meta()` with `get_project_type()`, return full project_type object
- **#12**: Add `chubes/get-doc` ability — fetch full doc content by ID or slug with project, project_type, meta
- **#13**: Include `project_type` (id, name, slug) in search results, REST doc responses, and project tree endpoint
- **#14**: Auto-generate excerpts from content (first ~30 words) during sync and at query time as fallback