### PR TITLE
feat: store raw markdown and serve as default API format

### DIFF
--- a/inc/Abilities/DocsAbilities.php
+++ b/inc/Abilities/DocsAbilities.php
@@ -38,6 +38,12 @@ class DocsAbilities {
 						'type'        => 'string',
 						'description' => 'Post slug',
 					],
+					'format' => [
+						'type'        => 'string',
+						'description' => 'Content format: "markdown" (default) or "html"',
+						'enum'        => [ 'markdown', 'html' ],
+						'default'     => 'markdown',
+					],
 				],
 			],
 			'output_schema'       => [
@@ -108,10 +114,21 @@ class DocsAbilities {
 			$excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 30, '...' );
 		}
 
+		$format = $input['format'] ?? 'markdown';
+		if ( $format === 'markdown' ) {
+			$markdown = get_post_meta( $post->ID, '_sync_markdown', true );
+			$content = ! empty( $markdown ) ? $markdown : $post->post_content;
+			$content_format = ! empty( $markdown ) ? 'markdown' : 'html';
+		} else {
+			$content = $post->post_content;
+			$content_format = 'html';
+		}
+
 		return [
-			'id'           => $post->ID,
-			'title'        => get_the_title( $post ),
-			'content'      => $post->post_content,
+			'id'             => $post->ID,
+			'title'          => get_the_title( $post ),
+			'content'        => $content,
+			'content_format' => $content_format,
 			'excerpt'      => $excerpt,
 			'link'         => get_permalink( $post ),
 			'project'      => $project_data,

--- a/inc/Sync/SyncManager.php
+++ b/inc/Sync/SyncManager.php
@@ -26,6 +26,9 @@ class SyncManager {
 		}
 		$project_slug = $project_term->slug;
 
+		// Store raw markdown before HTML conversion
+		$raw_markdown = $content;
+
 		$processor = new MarkdownProcessor( $project_slug, $source_file, $project_term_id );
 		$content   = $processor->process( $content );
 
@@ -75,6 +78,7 @@ class SyncManager {
 			}
 
 			self::update_sync_meta( $existing_post_id, $source_file, $filesize, $timestamp );
+			update_post_meta( $existing_post_id, '_sync_markdown', $raw_markdown );
 			wp_set_object_terms( $existing_post_id, $leaf_term_id, Project::TAXONOMY );
 
 			return [
@@ -104,6 +108,7 @@ class SyncManager {
 		}
 
 		self::update_sync_meta( $post_id, $source_file, $filesize, $timestamp );
+		update_post_meta( $post_id, '_sync_markdown', $raw_markdown );
 		wp_set_object_terms( $post_id, $leaf_term_id, Project::TAXONOMY );
 
 		return [


### PR DESCRIPTION
Stores raw markdown in `_sync_markdown` post meta during sync and serves it as the default API format.

**Changes:**
- **SyncManager**: saves raw markdown to `_sync_markdown` post meta before HTML conversion
- **DocsController**: `get_item` supports `format` query param (default: `markdown`, use `format=html` for HTML). Falls back to HTML if markdown not yet synced.
- **DocsAbilities**: `chubes/get-doc` ability accepts `format` input param with same behavior

Closes #16