### PR TITLE
Make template layer opt-in via theme support

### DIFF
--- a/docsync.php
+++ b/docsync.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: DocSync
- * Plugin URI: https://github.com/chubes4/chubes-docs
+ * Plugin URI: https://github.com/chubes4/docsync
  * Description: GitHub-to-WordPress documentation sync system with REST API, WP-CLI, and hierarchical project organization.
  * Version: 1.0.0
  * Author: Chris Huber
@@ -57,13 +57,28 @@ CronSync::init();
 SettingsPage::init();
 DocumentationColumns::init();
 
-add_action( 'init', function() {
-	RelatedPosts::init();
-	Breadcrumbs::init();
-	Archive::init();
-	Homepage::init();
-	SearchBar::init();
-} );
+/**
+ * Template layer — only loads when the active theme declares support.
+ *
+ * Themes opt in with: add_theme_support( 'docsync-templates' );
+ *
+ * Without theme support, DocSync registers the CPT, taxonomy, sync engine,
+ * REST API, WP-CLI, Abilities, and admin — but produces zero frontend output.
+ * The theme handles all rendering via standard WordPress template hierarchy.
+ */
+add_action( 'after_setup_theme', function() {
+	if ( ! current_theme_supports( 'docsync-templates' ) ) {
+		return;
+	}
+
+	add_action( 'init', function() {
+		RelatedPosts::init();
+		Breadcrumbs::init();
+		Archive::init();
+		Homepage::init();
+		SearchBar::init();
+	} );
+}, 20 );
 
 Abilities::init();
 

--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -20,8 +20,15 @@ class Assets {
 
 	/**
 	 * Handle all frontend asset enqueues.
+	 *
+	 * Only loads when the theme has opted into docsync-templates.
+	 * Without theme support, zero frontend assets are enqueued.
 	 */
 	public static function enqueue_frontend_assets() {
+		if ( ! current_theme_supports( 'docsync-templates' ) ) {
+			return;
+		}
+
 		self::enqueue_archive_assets();
 		self::enqueue_single_assets();
 	}


### PR DESCRIPTION
## Summary

- Templates and frontend assets now require `add_theme_support( 'docsync-templates' )` to load
- Without theme support: CPT, taxonomy, sync, REST API, WP-CLI, Abilities, admin all work — zero frontend output
- With theme support: full template integration (archive, related posts, breadcrumbs, homepage, search)

This is the key architectural change that makes DocSync usable on **any** WordPress site regardless of theme.

## For chubes.net

Add one line to the chubes theme's `functions.php`:
```php
add_theme_support( 'docsync-templates' );
```

## Closes

- #33 (Make template layer opt-in)
- Partially addresses #29 (Decouple from theme)