### PR TITLE
Add Table of Contents sidebar for documentation pages

### DIFF
--- a/assets/css/toc.css
+++ b/assets/css/toc.css
@@ -1,0 +1,63 @@
+/**
+ * DocSync Table of Contents Styles
+ *
+ * Standalone styles for the TOC sidebar. Uses --docsync-* design tokens
+ * with sensible fallbacks.
+ */
+
+.docsync-toc {
+	position: sticky;
+	top: 2rem;
+	padding: var(--docsync-space-lg, 1.5rem);
+	background: var(--docsync-background-card, #ffffff);
+	border: 1px solid var(--docsync-border-light, #e9ecef);
+	border-radius: 8px;
+}
+
+.docsync-toc-title {
+	margin: 0 0 var(--docsync-space-md, 0.75rem);
+	font-size: var(--docsync-font-size-sm, 0.875rem);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--docsync-muted-text-color, #868e96);
+}
+
+.docsync-toc-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.docsync-toc-item {
+	margin: 0;
+	padding: 0;
+}
+
+.docsync-toc-item.docsync-toc-nested {
+	padding-left: 1rem;
+}
+
+.docsync-toc-link {
+	display: block;
+	padding: 0.35rem 0.75rem;
+	margin: 1px 0;
+	font-size: var(--docsync-font-size-sm, 0.875rem);
+	line-height: 1.5;
+	color: var(--docsync-text-secondary, #495057);
+	text-decoration: none;
+	border-left: 2px solid transparent;
+	border-radius: 0 4px 4px 0;
+	transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.docsync-toc-link:hover {
+	color: var(--docsync-accent-strong, #0066cc);
+	background: var(--docsync-accent-subtle, #e6f0fa);
+}
+
+.docsync-toc-link.docsync-toc-active {
+	color: var(--docsync-accent-strong, #0066cc);
+	border-left-color: var(--docsync-accent-strong, #0066cc);
+	font-weight: 500;
+}

--- a/assets/js/docsync-toc.js
+++ b/assets/js/docsync-toc.js
@@ -1,0 +1,79 @@
+/**
+ * DocSync Table of Contents — scroll spy and smooth navigation.
+ *
+ * Highlights the current section in the TOC sidebar as the user scrolls.
+ * Uses IntersectionObserver for performant scroll tracking.
+ */
+( function() {
+	'use strict';
+
+	const toc = document.querySelector( '.docsync-toc' );
+	if ( ! toc ) {
+		return;
+	}
+
+	const links = toc.querySelectorAll( '.docsync-toc-link' );
+	if ( ! links.length ) {
+		return;
+	}
+
+	const ACTIVE_CLASS = 'docsync-toc-active';
+
+	// Collect target sections.
+	const sections = [];
+	links.forEach( function( link ) {
+		const id = link.getAttribute( 'href' ).replace( '#', '' );
+		const el = document.getElementById( id );
+		if ( el ) {
+			sections.push( { id: id, el: el, link: link } );
+		}
+	} );
+
+	if ( ! sections.length ) {
+		return;
+	}
+
+	// Scroll spy via IntersectionObserver.
+	let currentActive = null;
+
+	const observer = new IntersectionObserver(
+		function( entries ) {
+			entries.forEach( function( entry ) {
+				if ( entry.isIntersecting ) {
+					const section = sections.find( function( s ) {
+						return s.el === entry.target;
+					} );
+
+					if ( section && section.link !== currentActive ) {
+						if ( currentActive ) {
+							currentActive.classList.remove( ACTIVE_CLASS );
+						}
+						section.link.classList.add( ACTIVE_CLASS );
+						currentActive = section.link;
+					}
+				}
+			} );
+		},
+		{
+			rootMargin: '-80px 0px -60% 0px',
+			threshold: 0,
+		}
+	);
+
+	sections.forEach( function( section ) {
+		observer.observe( section.el );
+	} );
+
+	// Smooth scroll on click.
+	links.forEach( function( link ) {
+		link.addEventListener( 'click', function( e ) {
+			e.preventDefault();
+			const id = this.getAttribute( 'href' ).replace( '#', '' );
+			const target = document.getElementById( id );
+			if ( target ) {
+				target.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+				history.replaceState( null, '', '#' + id );
+			}
+		} );
+	} );
+} )();

--- a/docsync.php
+++ b/docsync.php
@@ -37,6 +37,7 @@ use DocSync\Templates\Archive;
 use DocSync\Templates\ProjectCard;
 use DocSync\Templates\Homepage;
 use DocSync\Templates\SearchBar;
+use DocSync\Templates\TableOfContents;
 use DocSync\Sync\CronSync;
 use DocSync\Admin\SettingsPage;
 use DocSync\Admin\ProjectColumns;
@@ -77,6 +78,7 @@ add_action( 'after_setup_theme', function() {
 		Archive::init();
 		Homepage::init();
 		SearchBar::init();
+		TableOfContents::init();
 	} );
 }, 20 );
 

--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -166,5 +166,27 @@ class Assets {
 			[ 'docsync-tokens' ],
 			filemtime( DOCSYNC_PATH . 'assets/css/related-posts.css' )
 		);
+
+		self::enqueue_toc_assets();
+	}
+
+	/**
+	 * Enqueue Table of Contents sidebar assets.
+	 */
+	private static function enqueue_toc_assets() {
+		wp_enqueue_style(
+			'docsync-toc',
+			DOCSYNC_URL . 'assets/css/toc.css',
+			[ 'docsync-tokens' ],
+			filemtime( DOCSYNC_PATH . 'assets/css/toc.css' )
+		);
+
+		wp_enqueue_script(
+			'docsync-toc',
+			DOCSYNC_URL . 'assets/js/docsync-toc.js',
+			[],
+			filemtime( DOCSYNC_PATH . 'assets/js/docsync-toc.js' ),
+			true
+		);
 	}
 }

--- a/inc/Templates/TableOfContents.php
+++ b/inc/Templates/TableOfContents.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Table of Contents Sidebar
+ *
+ * Generates a sticky TOC from post content headings for single
+ * documentation pages. Includes scroll-spy via docsync-toc.js.
+ *
+ * Ported from extrachill-docs with enhancements for nested heading support.
+ *
+ * @package DocSync\Templates
+ * @since 1.0.0
+ */
+
+namespace DocSync\Templates;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class TableOfContents {
+
+	/**
+	 * Initialize TOC hooks.
+	 *
+	 * Hooks into docsync_single_sidebar filter to provide sidebar content.
+	 * Also adds heading IDs to post content if not present.
+	 */
+	public static function init(): void {
+		add_filter( 'docsync_single_sidebar', [ __CLASS__, 'render' ], 10, 2 );
+		add_filter( 'the_content', [ __CLASS__, 'ensure_heading_ids' ], 5 );
+	}
+
+	/**
+	 * Render TOC sidebar HTML for a documentation post.
+	 *
+	 * @param string $sidebar_content Existing sidebar content.
+	 * @param int    $post_id         Current post ID.
+	 * @return string TOC HTML or existing content if no headings found.
+	 */
+	public static function render( string $sidebar_content, int $post_id ): string {
+		$content = get_post_field( 'post_content', $post_id );
+
+		if ( empty( $content ) ) {
+			return $sidebar_content;
+		}
+
+		// Apply content filters to get rendered HTML (blocks → HTML).
+		$rendered = apply_filters( 'docsync_toc_content', $content );
+
+		// Extract h2 and h3 headings with IDs.
+		preg_match_all(
+			'/<(h[23])[^>]*id=["\']([^"\']+)["\'][^>]*>(.*?)<\/\1>/i',
+			$rendered,
+			$matches,
+			PREG_SET_ORDER
+		);
+
+		if ( empty( $matches ) ) {
+			return $sidebar_content;
+		}
+
+		$headers = [];
+		foreach ( $matches as $match ) {
+			$headers[] = [
+				'level' => $match[1],
+				'id'    => $match[2],
+				'text'  => wp_strip_all_tags( $match[3] ),
+			];
+		}
+
+		ob_start();
+		?>
+		<nav class="docsync-toc" aria-label="<?php esc_attr_e( 'Table of Contents', 'docsync' ); ?>">
+			<h3 class="docsync-toc-title"><span><?php esc_html_e( 'On This Page', 'docsync' ); ?></span></h3>
+			<?php echo self::build_list( $headers ); ?>
+		</nav>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Build the TOC list HTML from headers array.
+	 *
+	 * Supports nested h2 → h3 hierarchy.
+	 *
+	 * @param array $headers Array of header data with level, id, text.
+	 * @return string HTML list.
+	 */
+	private static function build_list( array $headers ): string {
+		$html = '<ul class="docsync-toc-list">';
+
+		foreach ( $headers as $header ) {
+			$indent_class = $header['level'] === 'h3' ? ' docsync-toc-nested' : '';
+			$html .= sprintf(
+				'<li class="docsync-toc-item%s"><a href="#%s" class="docsync-toc-link">%s</a></li>',
+				$indent_class,
+				esc_attr( $header['id'] ),
+				esc_html( $header['text'] )
+			);
+		}
+
+		$html .= '</ul>';
+
+		return $html;
+	}
+
+	/**
+	 * Ensure all h2 and h3 elements in documentation content have IDs.
+	 *
+	 * Adds slug-based IDs to headings that don't already have one,
+	 * so the TOC can link to them.
+	 *
+	 * @param string $content Post content.
+	 * @return string Content with heading IDs ensured.
+	 */
+	public static function ensure_heading_ids( string $content ): string {
+		if ( ! is_singular( 'documentation' ) ) {
+			return $content;
+		}
+
+		return preg_replace_callback(
+			'/<(h[23])([^>]*)>(.*?)<\/\1>/i',
+			function( $matches ) {
+				$tag   = $matches[1];
+				$attrs = $matches[2];
+				$text  = $matches[3];
+
+				// Already has an ID — leave it alone.
+				if ( preg_match( '/id=["\']/', $attrs ) ) {
+					return $matches[0];
+				}
+
+				$id = sanitize_title( wp_strip_all_tags( $text ) );
+				return sprintf( '<%s%s id="%s">%s</%s>', $tag, $attrs, esc_attr( $id ), $text, $tag );
+			},
+			$content
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Ports the TOC sidebar from extrachill-docs with improvements:

- **h2 + h3 support** (extrachill only did h2) with nested indentation
- **IntersectionObserver** scroll spy (replaces scroll event listeners)
- **Auto-generates heading IDs** if missing (`the_content` filter)
- **Standalone CSS** using `--docsync-*` tokens
- **Sticky positioning** for long documents
- **Smooth scroll** with URL hash update

Hooks into `docsync_single_sidebar` filter for theme placement.

## New files

- `inc/Templates/TableOfContents.php` — PHP component
- `assets/js/docsync-toc.js` — scroll spy + smooth scroll
- `assets/css/toc.css` — standalone styles

## Closes

- #32 (Port TOC sidebar from extrachill-docs)