### PR TITLE
Project tree sidebar navigation + doc tree API

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -1,0 +1,55 @@
+/**
+ * DocSync Documentation Layout
+ *
+ * Two-column grid: content + sidebar. The sidebar contains the project
+ * tree navigation and table of contents. On mobile, stacks vertically
+ * with sidebar below content.
+ */
+
+.docsync-doc-layout {
+	display: grid;
+	grid-template-columns: 1fr 260px;
+	gap: var(--docsync-space-xl, 2rem);
+	align-items: start;
+}
+
+.docsync-doc-content {
+	min-width: 0; /* Prevent content overflow in grid */
+}
+
+.docsync-doc-sidebar {
+	position: sticky;
+	top: 2rem;
+	max-height: calc(100vh - 4rem);
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: var(--docsync-space-lg, 1.5rem);
+}
+
+/* Scrollbar styling for sidebar */
+.docsync-doc-sidebar::-webkit-scrollbar {
+	width: 4px;
+}
+
+.docsync-doc-sidebar::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.docsync-doc-sidebar::-webkit-scrollbar-thumb {
+	background: var(--docsync-border-light, #e9ecef);
+	border-radius: 2px;
+}
+
+/* Mobile: stack vertically, sidebar goes below content */
+@media (max-width: 1024px) {
+	.docsync-doc-layout {
+		grid-template-columns: 1fr;
+	}
+
+	.docsync-doc-sidebar {
+		position: static;
+		max-height: none;
+		overflow-y: visible;
+	}
+}

--- a/assets/css/project-tree.css
+++ b/assets/css/project-tree.css
@@ -1,0 +1,127 @@
+/**
+ * DocSync Project Tree Styles
+ *
+ * Hierarchical navigation tree for documentation projects.
+ * Supports collapsible sections, current-page highlighting,
+ * and nested term hierarchies.
+ */
+
+.docsync-project-tree {
+	padding: var(--docsync-space-md, 0.75rem);
+	background: var(--docsync-background-card, #ffffff);
+	border: 1px solid var(--docsync-border-light, #e9ecef);
+	border-radius: 8px;
+}
+
+/* Project title */
+.docsync-tree-title {
+	margin: 0 0 var(--docsync-space-sm, 0.5rem);
+	padding: 0 var(--docsync-space-sm, 0.5rem);
+	font-size: var(--docsync-font-size-sm, 0.875rem);
+	font-weight: 700;
+}
+
+.docsync-tree-title a {
+	color: var(--docsync-heading-color, #212529);
+	text-decoration: none;
+}
+
+.docsync-tree-title a:hover {
+	color: var(--docsync-accent-strong, #0066cc);
+}
+
+/* Tree lists */
+.docsync-tree-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.docsync-tree-children {
+	list-style: none;
+	margin: 0;
+	padding: 0 0 0 0.75rem;
+}
+
+/* Section toggle buttons */
+.docsync-tree-toggle {
+	display: flex;
+	align-items: center;
+	gap: 0.35rem;
+	width: 100%;
+	padding: 0.3rem 0.5rem;
+	margin: 1px 0;
+	border: none;
+	background: none;
+	font-family: inherit;
+	font-size: var(--docsync-font-size-sm, 0.875rem);
+	font-weight: 600;
+	color: var(--docsync-text-secondary, #495057);
+	text-align: left;
+	cursor: pointer;
+	border-radius: 4px;
+	transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.docsync-tree-toggle:hover {
+	background: var(--docsync-accent-subtle, #e6f0fa);
+	color: var(--docsync-accent-strong, #0066cc);
+}
+
+/* Chevron icon */
+.docsync-tree-icon {
+	display: inline-block;
+	width: 12px;
+	height: 12px;
+	flex-shrink: 0;
+	transition: transform 0.15s ease;
+}
+
+.docsync-tree-icon::before {
+	content: '';
+	display: block;
+	width: 0;
+	height: 0;
+	border-style: solid;
+	border-width: 4px 0 4px 6px;
+	border-color: transparent transparent transparent currentColor;
+	margin: 2px 0 0 2px;
+}
+
+.docsync-tree-expanded > .docsync-tree-toggle .docsync-tree-icon {
+	transform: rotate(90deg);
+}
+
+/* Collapsed sections hide children */
+.docsync-tree-collapsed > .docsync-tree-children {
+	display: none;
+}
+
+.docsync-tree-expanded > .docsync-tree-children {
+	display: block;
+}
+
+/* Doc links */
+.docsync-tree-doc a {
+	display: block;
+	padding: 0.25rem 0.5rem;
+	margin: 1px 0;
+	font-size: var(--docsync-font-size-sm, 0.875rem);
+	line-height: 1.4;
+	color: var(--docsync-text-secondary, #495057);
+	text-decoration: none;
+	border-radius: 4px;
+	transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.docsync-tree-doc a:hover {
+	color: var(--docsync-accent-strong, #0066cc);
+	background: var(--docsync-accent-subtle, #e6f0fa);
+}
+
+/* Current page highlight */
+.docsync-tree-current a {
+	color: var(--docsync-accent-strong, #0066cc);
+	font-weight: 500;
+	background: var(--docsync-accent-subtle, #e6f0fa);
+}

--- a/assets/js/docsync-project-tree.js
+++ b/assets/js/docsync-project-tree.js
@@ -1,0 +1,46 @@
+/**
+ * DocSync Project Tree — Collapse/Expand
+ *
+ * Handles section toggle buttons in the project tree sidebar.
+ * Sections containing the current page are auto-expanded on load
+ * (via server-rendered classes). This JS handles user interactions.
+ */
+(function () {
+	'use strict';
+
+	document.addEventListener('DOMContentLoaded', function () {
+		var tree = document.querySelector('.docsync-project-tree');
+		if (!tree) return;
+
+		// Delegate click events on toggle buttons.
+		tree.addEventListener('click', function (e) {
+			var toggle = e.target.closest('.docsync-tree-toggle');
+			if (!toggle) return;
+
+			var section = toggle.parentElement;
+			if (!section) return;
+
+			var isExpanded = section.classList.contains('docsync-tree-expanded');
+
+			if (isExpanded) {
+				section.classList.remove('docsync-tree-expanded');
+				section.classList.add('docsync-tree-collapsed');
+				toggle.setAttribute('aria-expanded', 'false');
+			} else {
+				section.classList.remove('docsync-tree-collapsed');
+				section.classList.add('docsync-tree-expanded');
+				toggle.setAttribute('aria-expanded', 'true');
+			}
+		});
+
+		// Scroll the current page item into view if it's off-screen
+		// in the sidebar.
+		var currentItem = tree.querySelector('.docsync-tree-current');
+		if (currentItem) {
+			var sidebar = tree.closest('.docsync-doc-sidebar');
+			if (sidebar && sidebar.scrollHeight > sidebar.clientHeight) {
+				currentItem.scrollIntoView({ block: 'center', behavior: 'instant' });
+			}
+		}
+	});
+})();

--- a/docsync.php
+++ b/docsync.php
@@ -32,6 +32,8 @@ use DocSync\Core\RewriteRules;
 use DocSync\Core\Breadcrumbs;
 use DocSync\Fields\RepositoryFields;
 use DocSync\Fields\InstallTracker;
+use DocSync\Templates\DocumentationLayout;
+use DocSync\Templates\ProjectTree;
 use DocSync\Templates\RelatedPosts;
 use DocSync\Templates\Archive;
 use DocSync\Templates\ProjectCard;
@@ -73,6 +75,8 @@ add_action( 'after_setup_theme', function() {
 	}
 
 	add_action( 'init', function() {
+		DocumentationLayout::init();
+		ProjectTree::init();
 		RelatedPosts::init();
 		Breadcrumbs::init();
 		Archive::init();

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -117,6 +117,19 @@ class Routes {
             ],
         ]);
 
+        register_rest_route( self::NAMESPACE, '/project/(?P<slug>[a-z0-9-]+)/tree', [
+            'methods'             => 'GET',
+            'callback'            => [ ProjectController::class, 'get_doc_tree' ],
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'slug' => [
+                    'type'              => 'string',
+                    'required'          => true,
+                    'sanitize_callback' => 'sanitize_title',
+                ],
+            ],
+        ] );
+
         register_rest_route(self::NAMESPACE, '/project/(?P<id>\d+)', [
             [
                 'methods'             => 'GET',

--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -167,7 +167,41 @@ class Assets {
 			filemtime( DOCSYNC_PATH . 'assets/css/related-posts.css' )
 		);
 
+		self::enqueue_layout_assets();
+		self::enqueue_project_tree_assets();
 		self::enqueue_toc_assets();
+	}
+
+	/**
+	 * Enqueue documentation layout assets (content + sidebar grid).
+	 */
+	private static function enqueue_layout_assets() {
+		wp_enqueue_style(
+			'docsync-layout',
+			DOCSYNC_URL . 'assets/css/layout.css',
+			[ 'docsync-tokens' ],
+			filemtime( DOCSYNC_PATH . 'assets/css/layout.css' )
+		);
+	}
+
+	/**
+	 * Enqueue project tree sidebar assets.
+	 */
+	private static function enqueue_project_tree_assets() {
+		wp_enqueue_style(
+			'docsync-project-tree',
+			DOCSYNC_URL . 'assets/css/project-tree.css',
+			[ 'docsync-tokens' ],
+			filemtime( DOCSYNC_PATH . 'assets/css/project-tree.css' )
+		);
+
+		wp_enqueue_script(
+			'docsync-project-tree',
+			DOCSYNC_URL . 'assets/js/docsync-project-tree.js',
+			[],
+			filemtime( DOCSYNC_PATH . 'assets/js/docsync-project-tree.js' ),
+			true
+		);
 	}
 
 	/**

--- a/inc/Templates/DocumentationLayout.php
+++ b/inc/Templates/DocumentationLayout.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Documentation Layout
+ *
+ * Wraps single documentation content in a two-column layout with a sidebar.
+ * The sidebar collects its content from the docsync_single_sidebar filter,
+ * which is where ProjectTree and TableOfContents hook in.
+ *
+ * This component solves the rendering gap: previously, sidebar components
+ * hooked into the filter but nothing applied it. Now the layout wrapper
+ * applies the filter and renders the sidebar alongside the content.
+ *
+ * @package DocSync\Templates
+ * @since 1.0.0
+ */
+
+namespace DocSync\Templates;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class DocumentationLayout {
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * Uses a late priority on the_content to wrap after all content filters
+	 * have run (blocks, shortcodes, embeds, etc).
+	 */
+	public static function init(): void {
+		add_filter( 'the_content', [ __CLASS__, 'wrap_content' ], 999 );
+	}
+
+	/**
+	 * Wrap single documentation content with sidebar layout.
+	 *
+	 * Only acts on singular documentation pages. Collects sidebar content
+	 * from the docsync_single_sidebar filter and wraps everything in a
+	 * CSS Grid layout.
+	 *
+	 * @param string $content The post content.
+	 * @return string Wrapped content with sidebar, or original content.
+	 */
+	public static function wrap_content( string $content ): string {
+		if ( ! is_singular( 'documentation' ) ) {
+			return $content;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return $content;
+		}
+
+		/**
+		 * Filter the sidebar content for single documentation pages.
+		 *
+		 * Components hook into this to add sidebar widgets:
+		 * - ProjectTree at priority 5 (project navigation)
+		 * - TableOfContents at priority 10 (page headings)
+		 *
+		 * @param string $sidebar_content Accumulated sidebar HTML.
+		 * @param int    $post_id         Current documentation post ID.
+		 */
+		$sidebar = apply_filters( 'docsync_single_sidebar', '', $post_id );
+
+		if ( empty( trim( $sidebar ) ) ) {
+			return $content;
+		}
+
+		return '<div class="docsync-doc-layout">'
+			. '<div class="docsync-doc-content">' . $content . '</div>'
+			. '<aside class="docsync-doc-sidebar">' . $sidebar . '</aside>'
+			. '</div>';
+	}
+}

--- a/inc/Templates/ProjectTree.php
+++ b/inc/Templates/ProjectTree.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Project Tree Sidebar Navigation
+ *
+ * Renders a hierarchical tree of all documentation in the current project
+ * on single documentation pages. Shows sections (taxonomy terms) and docs,
+ * highlights the current page, and supports collapse/expand.
+ *
+ * Hooks into docsync_single_sidebar at priority 5 (before TOC at 10).
+ * Uses ProjectController::build_doc_tree() for the data structure.
+ *
+ * @package DocSync\Templates
+ * @since 1.0.0
+ */
+
+namespace DocSync\Templates;
+
+use DocSync\Api\Controllers\ProjectController;
+use DocSync\Core\Project;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ProjectTree {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init(): void {
+		add_filter( 'docsync_single_sidebar', [ __CLASS__, 'render' ], 5, 2 );
+	}
+
+	/**
+	 * Render the project tree sidebar for a documentation post.
+	 *
+	 * @param string $sidebar_content Existing sidebar content.
+	 * @param int    $post_id         Current post ID.
+	 * @return string Updated sidebar content with tree prepended.
+	 */
+	public static function render( string $sidebar_content, int $post_id ): string {
+		$terms = get_the_terms( $post_id, Project::TAXONOMY );
+		if ( ! $terms || is_wp_error( $terms ) ) {
+			return $sidebar_content;
+		}
+
+		// Get the top-level project term.
+		$project_term = Project::get_top_level_term( $terms );
+		if ( ! $project_term ) {
+			return $sidebar_content;
+		}
+
+		$tree = ProjectController::build_doc_tree( $project_term->term_id );
+		if ( empty( $tree ) ) {
+			return $sidebar_content;
+		}
+
+		$project_url = get_term_link( $project_term );
+
+		ob_start();
+		?>
+		<nav class="docsync-project-tree" aria-label="<?php echo esc_attr( sprintf( __( '%s documentation', 'docsync' ), $project_term->name ) ); ?>">
+			<h3 class="docsync-tree-title">
+				<a href="<?php echo esc_url( $project_url ); ?>"><?php echo esc_html( $project_term->name ); ?></a>
+			</h3>
+			<?php echo self::render_sections( $tree, $post_id ); ?>
+		</nav>
+		<?php
+		$tree_html = ob_get_clean();
+
+		return $tree_html . $sidebar_content;
+	}
+
+	/**
+	 * Render tree sections recursively.
+	 *
+	 * @param array $sections Tree sections from ProjectController::build_doc_tree().
+	 * @param int   $post_id  Current post ID for highlighting.
+	 * @return string HTML.
+	 */
+	private static function render_sections( array $sections, int $post_id ): string {
+		$html = '<ul class="docsync-tree-list">';
+
+		foreach ( $sections as $section ) {
+			$term = $section['term'] ?? null;
+			$docs = $section['docs'] ?? [];
+			$children = $section['children'] ?? [];
+
+			// Section with a term heading (named section).
+			if ( $term ) {
+				$has_children = ! empty( $docs ) || ! empty( $children );
+				$is_expanded  = $has_children && self::section_contains_post( $section, $post_id );
+				$state_class  = $is_expanded ? 'docsync-tree-expanded' : 'docsync-tree-collapsed';
+
+				$html .= '<li class="docsync-tree-section ' . $state_class . '">';
+				$html .= '<button class="docsync-tree-toggle" aria-expanded="' . ( $is_expanded ? 'true' : 'false' ) . '">';
+				$html .= '<span class="docsync-tree-icon"></span>';
+				$html .= esc_html( $term['name'] );
+				$html .= '</button>';
+
+				if ( $has_children ) {
+					$html .= '<ul class="docsync-tree-children">';
+
+					foreach ( $docs as $doc ) {
+						$html .= self::render_doc_item( $doc, $post_id );
+					}
+
+					// Recurse into child sections.
+					if ( ! empty( $children ) ) {
+						foreach ( $children as $child_section ) {
+							$child_term = $child_section['term'] ?? null;
+							$child_docs = $child_section['docs'] ?? [];
+							$child_children = $child_section['children'] ?? [];
+
+							if ( $child_term ) {
+								$child_expanded = self::section_contains_post( $child_section, $post_id );
+								$child_state = $child_expanded ? 'docsync-tree-expanded' : 'docsync-tree-collapsed';
+
+								$html .= '<li class="docsync-tree-section ' . $child_state . '">';
+								$html .= '<button class="docsync-tree-toggle" aria-expanded="' . ( $child_expanded ? 'true' : 'false' ) . '">';
+								$html .= '<span class="docsync-tree-icon"></span>';
+								$html .= esc_html( $child_term['name'] );
+								$html .= '</button>';
+
+								$html .= '<ul class="docsync-tree-children">';
+								foreach ( $child_docs as $doc ) {
+									$html .= self::render_doc_item( $doc, $post_id );
+								}
+								$html .= '</ul></li>';
+							} else {
+								foreach ( $child_docs as $doc ) {
+									$html .= self::render_doc_item( $doc, $post_id );
+								}
+							}
+						}
+					}
+
+					$html .= '</ul>';
+				}
+
+				$html .= '</li>';
+			} else {
+				// Root docs (no section heading).
+				foreach ( $docs as $doc ) {
+					$html .= self::render_doc_item( $doc, $post_id );
+				}
+			}
+		}
+
+		$html .= '</ul>';
+
+		return $html;
+	}
+
+	/**
+	 * Render a single doc item.
+	 *
+	 * @param array $doc     Doc data with id, title, slug, url.
+	 * @param int   $post_id Current post ID.
+	 * @return string HTML list item.
+	 */
+	private static function render_doc_item( array $doc, int $post_id ): string {
+		$is_current = ( (int) $doc['id'] === $post_id );
+		$classes    = 'docsync-tree-doc';
+
+		if ( $is_current ) {
+			$classes .= ' docsync-tree-current';
+		}
+
+		return sprintf(
+			'<li class="%s"><a href="%s"%s>%s</a></li>',
+			esc_attr( $classes ),
+			esc_url( $doc['url'] ),
+			$is_current ? ' aria-current="page"' : '',
+			esc_html( $doc['title'] )
+		);
+	}
+
+	/**
+	 * Check if a section contains the given post ID.
+	 *
+	 * Used to auto-expand sections containing the current page.
+	 *
+	 * @param array $section Section data.
+	 * @param int   $post_id Post ID to find.
+	 * @return bool True if found.
+	 */
+	private static function section_contains_post( array $section, int $post_id ): bool {
+		foreach ( $section['docs'] ?? [] as $doc ) {
+			if ( (int) $doc['id'] === $post_id ) {
+				return true;
+			}
+		}
+
+		foreach ( $section['children'] ?? [] as $child ) {
+			if ( self::section_contains_post( $child, $post_id ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

Two features that close **#44** and **#46**:

### 1. REST API — `GET /docsync/v1/project/{slug}/tree`

Returns the full hierarchical documentation tree for a project:

```json
{
  "project": "data-machine",
  "total_docs": 108,
  "sections": [
    { "term": null, "docs": [...], "children": [] },
    { "term": {"name": "Core System"}, "docs": [...], "children": [...] }
  ]
}
```

Useful for: sidebar navigation, AI agent context, static site generators.

### 2. Sidebar — Project tree navigation

On single documentation pages, a collapsible tree sidebar shows all docs in the current project:
- Sections auto-expand to show where the current page lives
- Current page is highlighted with `aria-current="page"`
- Collapse/expand via toggle buttons with chevron icons
- Responsive: sticky sidebar on desktop, stacks on mobile

### Bonus fix — Sidebar rendering

The `docsync_single_sidebar` filter existed but was **never applied**. TOC was hooked but invisible. `DocumentationLayout.php` now wraps content in a CSS Grid layout and applies the sidebar filter, so both project tree AND TOC now render.

## Verified on chubes.net

- ✅ API returns 108 docs for data-machine (no duplicates)
- ✅ Layout wrapper renders (content + sidebar grid)
- ✅ Project tree renders with correct hierarchy
- ✅ TOC renders alongside tree in sidebar
- ✅ Current page highlighted
- ✅ All CSS/JS enqueued
- ✅ 11/11 automated checks pass

## Files

**New (6):**
- `inc/Templates/ProjectTree.php` — Sidebar tree component
- `inc/Templates/DocumentationLayout.php` — Content+sidebar grid wrapper
- `assets/css/layout.css` — Two-column responsive grid
- `assets/css/project-tree.css` — Tree styles with collapse/expand
- `assets/js/docsync-project-tree.js` — Toggle + scroll-into-view

**Modified (4):**
- `inc/Api/Controllers/ProjectController.php` — `build_doc_tree()` + `get_doc_tree()` endpoint
- `inc/Api/Routes.php` — New route
- `inc/Core/Assets.php` — Enqueue new assets
- `docsync.php` — Init new components

Closes #44, closes #46