### PR TITLE
Fix mobile layout, collapsible sidebar, and pagination

### DIFF
--- a/assets/css/archives.css
+++ b/assets/css/archives.css
@@ -750,6 +750,7 @@
    Documentation Content Tables
    ========================================================================== */
 
+/* Wrap tables in a scrollable container for mobile */
 .documentation-content table,
 .entry-content table,
 .single-documentation table {
@@ -757,33 +758,6 @@
     border-collapse: collapse;
     margin: var(--docsync-space-xl) 0;
     font-size: var(--docsync-font-size-sm);
-    overflow-x: auto;
-    display: block;
-}
-
-.documentation-content thead,
-.entry-content thead,
-.single-documentation thead {
-    display: table-header-group;
-}
-
-.documentation-content tbody,
-.entry-content tbody,
-.single-documentation tbody {
-    display: table-row-group;
-}
-
-.documentation-content tr,
-.entry-content tr,
-.single-documentation tr {
-    display: table-row;
-}
-
-.documentation-content table,
-.entry-content table,
-.single-documentation table {
-    display: table;
-    overflow-x: auto;
 }
 
 .documentation-content th,
@@ -829,4 +803,108 @@
 
 .table-responsive table {
     margin: 0;
+}
+
+/* ==========================================================================
+   Content Overflow Protection
+   ========================================================================== */
+
+/* Pre/code blocks scroll horizontally instead of stretching the page */
+.single-documentation pre,
+.documentation-content pre,
+.entry-content pre {
+    overflow-x: auto;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
+}
+
+.single-documentation code,
+.documentation-content code,
+.entry-content code {
+    word-break: break-all;
+}
+
+/* Long URLs and text don't break layout */
+.single-documentation .post-content,
+.documentation-content,
+.entry-content {
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+/* Images constrained to content width */
+.single-documentation img,
+.documentation-content img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* ==========================================================================
+   Pagination
+   ========================================================================== */
+
+.docsync-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 2rem 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--docsync-border-light, #e9ecef);
+    flex-wrap: wrap;
+}
+
+.docsync-pagination a,
+.docsync-pagination span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    height: 2.25rem;
+    padding: 0.25rem 0.75rem;
+    border: 1px solid var(--docsync-border-default, #dee2e6);
+    border-radius: 6px;
+    font-size: var(--docsync-font-size-sm, 0.875rem);
+    text-decoration: none;
+    transition: all 0.15s ease;
+}
+
+.docsync-pagination a {
+    color: var(--docsync-text-secondary, #495057);
+    background: var(--docsync-background-card, #ffffff);
+}
+
+.docsync-pagination a:hover {
+    color: var(--docsync-accent-strong, #0066cc);
+    border-color: var(--docsync-accent-strong, #0066cc);
+    background: var(--docsync-accent-subtle, #e6f0fa);
+}
+
+.docsync-pagination .current {
+    color: var(--docsync-text-contrast, #ffffff);
+    background: var(--docsync-accent-strong, #0066cc);
+    border-color: var(--docsync-accent-strong, #0066cc);
+    font-weight: 600;
+}
+
+.docsync-pagination .dots {
+    border: none;
+    background: none;
+    color: var(--docsync-text-secondary, #495057);
+    min-width: auto;
+    padding: 0 0.25rem;
+}
+
+@media (max-width: 768px) {
+    .docsync-pagination {
+        gap: 0.35rem;
+    }
+
+    .docsync-pagination a,
+    .docsync-pagination span {
+        min-width: 2rem;
+        height: 2rem;
+        padding: 0.25rem 0.5rem;
+        font-size: var(--docsync-font-size-xs, 0.75rem);
+    }
 }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -2,8 +2,8 @@
  * DocSync Documentation Layout
  *
  * Two-column grid: content + sidebar. The sidebar contains the project
- * tree navigation and table of contents. On mobile, stacks vertically
- * with sidebar below content.
+ * tree navigation and table of contents. On mobile, the sidebar moves
+ * above content as a collapsible panel.
  */
 
 .docsync-doc-layout {
@@ -15,6 +15,8 @@
 
 .docsync-doc-content {
 	min-width: 0; /* Prevent content overflow in grid */
+	overflow-wrap: break-word;
+	word-break: break-word;
 }
 
 .docsync-doc-sidebar {
@@ -41,15 +43,92 @@
 	border-radius: 2px;
 }
 
-/* Mobile: stack vertically, sidebar goes below content */
+/* === Mobile sidebar toggle === */
+
+.docsync-sidebar-toggle {
+	display: none;
+}
+
+/* Mobile: sidebar above content as collapsible panel */
 @media (max-width: 1024px) {
 	.docsync-doc-layout {
-		grid-template-columns: 1fr;
+		display: flex;
+		flex-direction: column;
 	}
 
 	.docsync-doc-sidebar {
+		order: -1; /* Sidebar above content */
 		position: static;
 		max-height: none;
 		overflow-y: visible;
+	}
+
+	.docsync-sidebar-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.75rem 1rem;
+		margin-bottom: 0;
+		border: 1px solid var(--docsync-border-light, #e9ecef);
+		border-radius: 8px;
+		background: var(--docsync-background-card, #ffffff);
+		color: var(--docsync-text-secondary, #495057);
+		font-family: inherit;
+		font-size: var(--docsync-font-size-sm, 0.875rem);
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s ease;
+	}
+
+	.docsync-sidebar-toggle:hover {
+		background: var(--docsync-accent-subtle, #e6f0fa);
+	}
+
+	.docsync-sidebar-toggle-icon {
+		transition: transform 0.2s ease;
+		font-size: 0.7em;
+	}
+
+	.docsync-sidebar-toggle[aria-expanded="true"] .docsync-sidebar-toggle-icon {
+		transform: rotate(90deg);
+	}
+
+	/* Hide sidebar content by default on mobile */
+	.docsync-doc-sidebar .docsync-project-tree,
+	.docsync-doc-sidebar .docsync-toc {
+		display: none;
+	}
+
+	.docsync-doc-sidebar.docsync-sidebar-open .docsync-project-tree,
+	.docsync-doc-sidebar.docsync-sidebar-open .docsync-toc {
+		display: block;
+	}
+}
+
+/* === Global overflow protection for doc content === */
+
+.single-documentation .post-content {
+	overflow-x: hidden;
+}
+
+/* GitHub link on single docs */
+.docs-github-link {
+	margin-top: var(--docsync-space-xl, 1.5rem);
+	padding-top: var(--docsync-space-xl, 1.5rem);
+	border-top: 1px solid var(--docsync-border-default, #dee2e6);
+	overflow: hidden;
+}
+
+.docs-github-link a {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	max-width: 100%;
+}
+
+@media (max-width: 768px) {
+	.docs-github-link {
+		text-align: center;
 	}
 }

--- a/assets/js/docsync-project-tree.js
+++ b/assets/js/docsync-project-tree.js
@@ -1,18 +1,35 @@
 /**
- * DocSync Project Tree — Collapse/Expand
+ * DocSync Project Tree — Collapse/Expand + Mobile Sidebar Toggle
  *
- * Handles section toggle buttons in the project tree sidebar.
- * Sections containing the current page are auto-expanded on load
- * (via server-rendered classes). This JS handles user interactions.
+ * Handles section toggle buttons in the project tree sidebar and
+ * the mobile sidebar toggle that shows/hides the navigation panel.
  */
 (function () {
 	'use strict';
 
 	document.addEventListener('DOMContentLoaded', function () {
+		// === Mobile sidebar toggle ===
+		var sidebarToggle = document.querySelector('.docsync-sidebar-toggle');
+		var sidebar = document.querySelector('.docsync-doc-sidebar');
+
+		if (sidebarToggle && sidebar) {
+			sidebarToggle.addEventListener('click', function () {
+				var isOpen = sidebar.classList.contains('docsync-sidebar-open');
+
+				if (isOpen) {
+					sidebar.classList.remove('docsync-sidebar-open');
+					sidebarToggle.setAttribute('aria-expanded', 'false');
+				} else {
+					sidebar.classList.add('docsync-sidebar-open');
+					sidebarToggle.setAttribute('aria-expanded', 'true');
+				}
+			});
+		}
+
+		// === Project tree section toggles ===
 		var tree = document.querySelector('.docsync-project-tree');
 		if (!tree) return;
 
-		// Delegate click events on toggle buttons.
 		tree.addEventListener('click', function (e) {
 			var toggle = e.target.closest('.docsync-tree-toggle');
 			if (!toggle) return;
@@ -34,11 +51,11 @@
 		});
 
 		// Scroll the current page item into view if it's off-screen
-		// in the sidebar.
+		// in the sidebar (desktop only — mobile sidebar starts collapsed).
 		var currentItem = tree.querySelector('.docsync-tree-current');
-		if (currentItem) {
-			var sidebar = tree.closest('.docsync-doc-sidebar');
-			if (sidebar && sidebar.scrollHeight > sidebar.clientHeight) {
+		if (currentItem && sidebar && !sidebar.classList.contains('docsync-sidebar-open')) {
+			var isDesktop = window.matchMedia('(min-width: 1025px)').matches;
+			if (isDesktop && sidebar.scrollHeight > sidebar.clientHeight) {
 				currentItem.scrollIntoView({ block: 'center', behavior: 'instant' });
 			}
 		}

--- a/inc/Core/RewriteRules.php
+++ b/inc/Core/RewriteRules.php
@@ -68,6 +68,14 @@ class RewriteRules {
 		}
 
 		$path = trim( $wp->query_vars['docsync_path'], '/' );
+
+		// Extract pagination: strip trailing page/N from the path.
+		$paged = 1;
+		if ( preg_match( '#^(.+)/page/(\d+)$#', $path, $m ) ) {
+			$path  = $m[1];
+			$paged = (int) $m[2];
+		}
+
 		$segments = array_filter( explode( '/', $path ) );
 
 		if ( empty( $segments ) ) {
@@ -87,6 +95,9 @@ class RewriteRules {
 		if ( count( $segments ) === 1 ) {
 			unset( $wp->query_vars['docsync_path'] );
 			$wp->query_vars['project'] = $current_term->slug;
+			if ( $paged > 1 ) {
+				$wp->query_vars['paged'] = $paged;
+			}
 			return;
 		}
 
@@ -120,6 +131,9 @@ class RewriteRules {
 		// All segments matched terms - show deepest term archive
 		unset( $wp->query_vars['docsync_path'] );
 		$wp->query_vars['project'] = $current_term->slug;
+		if ( $paged > 1 ) {
+			$wp->query_vars['paged'] = $paged;
+		}
 	}
 
 	/**

--- a/inc/Templates/DocumentationLayout.php
+++ b/inc/Templates/DocumentationLayout.php
@@ -68,9 +68,14 @@ class DocumentationLayout {
 			return $content;
 		}
 
+		$toggle = '<button class="docsync-sidebar-toggle" aria-expanded="false" aria-controls="docsync-sidebar">'
+			. '<span class="docsync-sidebar-toggle-icon">&#9654;</span> '
+			. esc_html__( 'Navigation', 'docsync' )
+			. '</button>';
+
 		return '<div class="docsync-doc-layout">'
 			. '<div class="docsync-doc-content">' . $content . '</div>'
-			. '<aside class="docsync-doc-sidebar">' . $sidebar . '</aside>'
+			. '<aside class="docsync-doc-sidebar" id="docsync-sidebar">' . $toggle . $sidebar . '</aside>'
 			. '</div>';
 	}
 }


### PR DESCRIPTION
## Summary

- **Mobile overflow fixes** — `overflow-wrap: break-word` on content areas, constrained GitHub link, `overflow-x: auto` on pre/code, `max-width: 100%` on images, removed duplicate table CSS conflict
- **Collapsible mobile sidebar** — On screens ≤1024px the sidebar moves above content and hides behind a "Navigation" toggle button. Expands/collapses on tap with aria attributes.
- **Pagination** — Term archive pages now paginate at 12 docs/page with numbered links + prev/next. Hierarchy sections limited to 6 docs with "View all N docs →" link showing total count.
- **Rewrite rule fix** — `page/N` segments in DocsSync's catch-all URL resolver are now detected and mapped to WordPress `paged` query var instead of being treated as taxonomy slugs (which caused 404/blog fallback on page 2+).
- **Main query override** — `pre_get_posts` ensures the theme's archive template runs on paginated pages by keeping at least 1 post in the main query.

## Testing

All changes deployed and verified on chubes.net:
- `/docs/wordpress-core/rest-endpoints/` — 12 docs on page 1, pagination to page 3 (28 total)
- `/docs/wordpress-core/rest-endpoints/page/2/` — correct title, 12 docs, pagination renders
- `/docs/wordpress-core/` — 26 sections show "View all N docs →" links
- `/docs/data-machine/abilities-api/` — sidebar toggle + GitHub link render correctly
- `/docs/` — main archive unaffected

Closes #1 (mobile overflow), relates to #43 (navigation UX)