### PR TITLE
Replace sidebar filter system with docsync/navigation block

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -20,27 +20,9 @@
 }
 
 .docsync-doc-sidebar {
-	position: sticky;
-	top: 2rem;
-	max-height: calc(100vh - 4rem);
-	overflow-y: auto;
 	display: flex;
 	flex-direction: column;
 	gap: var(--docsync-space-lg, 1.5rem);
-}
-
-/* Scrollbar styling for sidebar */
-.docsync-doc-sidebar::-webkit-scrollbar {
-	width: 4px;
-}
-
-.docsync-doc-sidebar::-webkit-scrollbar-track {
-	background: transparent;
-}
-
-.docsync-doc-sidebar::-webkit-scrollbar-thumb {
-	background: var(--docsync-border-light, #e9ecef);
-	border-radius: 2px;
 }
 
 /* === Mobile sidebar toggle === */
@@ -106,9 +88,9 @@
 	}
 }
 
-/* === Global overflow protection for doc content === */
+/* === Overflow protection for doc content column only === */
 
-.single-documentation .post-content {
+.docsync-doc-content {
 	overflow-x: hidden;
 }
 

--- a/assets/css/toc.css
+++ b/assets/css/toc.css
@@ -8,10 +8,26 @@
 .docsync-toc {
 	position: sticky;
 	top: 2rem;
-	padding: var(--docsync-space-lg, 1.5rem);
+	max-height: calc(100vh - 4rem);
+	overflow-y: auto;
+	padding: var(--docsync-space-md, 0.75rem);
 	background: var(--docsync-background-card, #ffffff);
 	border: 1px solid var(--docsync-border-light, #e9ecef);
 	border-radius: 8px;
+}
+
+/* Scrollbar styling for TOC */
+.docsync-toc::-webkit-scrollbar {
+	width: 4px;
+}
+
+.docsync-toc::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.docsync-toc::-webkit-scrollbar-thumb {
+	background: var(--docsync-border-light, #e9ecef);
+	border-radius: 2px;
 }
 
 .docsync-toc-title {

--- a/blocks/navigation/block.json
+++ b/blocks/navigation/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "docsync/navigation",
+	"version": "1.0.0",
+	"title": "DocSync Navigation",
+	"category": "widgets",
+	"icon": "list-view",
+	"description": "Context-aware documentation navigation. Shows table of contents on single doc pages, project tree on archives.",
+	"textdomain": "docsync",
+	"attributes": {
+		"mode": {
+			"type": "string",
+			"default": "auto",
+			"enum": [ "auto", "toc", "tree" ]
+		},
+		"projectSlug": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": false,
+		"className": true
+	},
+	"editorScript": "file:./index.js",
+	"render": "file:../../inc/Blocks/render-navigation.php"
+}

--- a/blocks/navigation/index.js
+++ b/blocks/navigation/index.js
@@ -1,0 +1,93 @@
+/**
+ * DocSync Navigation Block — Editor Component
+ *
+ * Provides a simple block editor interface for the context-aware navigation.
+ * The actual rendering happens server-side via render callback.
+ */
+( function( wp ) {
+	'use strict';
+
+	const { registerBlockType } = wp.blocks;
+	const { useBlockProps, InspectorControls } = wp.blockEditor;
+	const { PanelBody, SelectControl, TextControl } = wp.components;
+	const { createElement: el } = wp.element;
+	const { __ } = wp.i18n;
+
+	registerBlockType( 'docsync/navigation', {
+		edit: function( props ) {
+			const { attributes, setAttributes } = props;
+			const blockProps = useBlockProps();
+
+			const modeLabels = {
+				auto: __( 'Auto (TOC on single, Tree on archive)', 'docsync' ),
+				toc: __( 'Table of Contents', 'docsync' ),
+				tree: __( 'Project Tree', 'docsync' ),
+			};
+
+			return el(
+				'div',
+				blockProps,
+				el(
+					InspectorControls,
+					null,
+					el(
+						PanelBody,
+						{ title: __( 'Navigation Settings', 'docsync' ), initialOpen: true },
+						el( SelectControl, {
+							label: __( 'Mode', 'docsync' ),
+							value: attributes.mode,
+							options: [
+								{ label: __( 'Auto-detect', 'docsync' ), value: 'auto' },
+								{ label: __( 'Table of Contents', 'docsync' ), value: 'toc' },
+								{ label: __( 'Project Tree', 'docsync' ), value: 'tree' },
+							],
+							onChange: function( value ) {
+								setAttributes( { mode: value } );
+							},
+							help: __( 'Auto mode shows TOC on single docs and project tree on archives.', 'docsync' ),
+						} ),
+						( attributes.mode === 'tree' || attributes.mode === 'auto' ) &&
+							el( TextControl, {
+								label: __( 'Project Slug', 'docsync' ),
+								value: attributes.projectSlug,
+								onChange: function( value ) {
+									setAttributes( { projectSlug: value } );
+								},
+								help: __( 'Leave empty to auto-detect from the current page context.', 'docsync' ),
+							} )
+					)
+				),
+				el(
+					'div',
+					{ className: 'docsync-navigation-placeholder' },
+					el(
+						'div',
+						{
+							style: {
+								padding: '1.5rem',
+								background: '#f8f9fa',
+								border: '1px dashed #ced4da',
+								borderRadius: '8px',
+								textAlign: 'center',
+								color: '#6c757d',
+								fontSize: '14px',
+							},
+						},
+						el( 'strong', null, __( 'DocSync Navigation', 'docsync' ) ),
+						el( 'br' ),
+						el(
+							'span',
+							{ style: { fontSize: '12px' } },
+							modeLabels[ attributes.mode ] || modeLabels.auto
+						)
+					)
+				)
+			);
+		},
+
+		save: function() {
+			// Dynamic block — rendered server-side.
+			return null;
+		},
+	} );
+} )( window.wp );

--- a/docsync.php
+++ b/docsync.php
@@ -25,6 +25,7 @@ require_once DOCSYNC_PATH . 'vendor/autoload.php';
 
 use DocSync\Api\Routes;
 use DocSync\Abilities\Abilities;
+use DocSync\Blocks\NavigationBlock;
 use DocSync\Core\Assets;
 use DocSync\Core\Documentation;
 use DocSync\Core\Project;
@@ -33,7 +34,6 @@ use DocSync\Core\Breadcrumbs;
 use DocSync\Fields\RepositoryFields;
 use DocSync\Fields\InstallTracker;
 use DocSync\Templates\DocumentationLayout;
-use DocSync\Templates\ProjectTree;
 use DocSync\Templates\RelatedPosts;
 use DocSync\Templates\Archive;
 use DocSync\Templates\ProjectCard;
@@ -61,6 +61,15 @@ SettingsPage::init();
 DocumentationColumns::init();
 
 /**
+ * Block registration — always available regardless of theme support.
+ *
+ * The docsync/navigation block is a standalone Gutenberg block that can
+ * be used in any context. Theme templates use do_blocks() to render it
+ * in the sidebar, and editors can drop it into any page.
+ */
+NavigationBlock::init();
+
+/**
  * Template layer — only loads when the active theme declares support.
  *
  * Themes opt in with: add_theme_support( 'docsync-templates' );
@@ -76,7 +85,6 @@ add_action( 'after_setup_theme', function() {
 
 	add_action( 'init', function() {
 		DocumentationLayout::init();
-		ProjectTree::init();
 		RelatedPosts::init();
 		Breadcrumbs::init();
 		Archive::init();

--- a/inc/Blocks/NavigationBlock.php
+++ b/inc/Blocks/NavigationBlock.php
@@ -1,0 +1,437 @@
+<?php
+/**
+ * Navigation Block
+ *
+ * Context-aware documentation navigation block. Renders as a table of
+ * contents (h2/h3 heading links) on single documentation pages, or as
+ * a hierarchical project tree on archives and landing pages.
+ *
+ * Replaces the old filter-based ProjectTree and TableOfContents sidebar
+ * components with a single reusable Gutenberg block.
+ *
+ * @package DocSync\Blocks
+ * @since 1.1.0
+ */
+
+namespace DocSync\Blocks;
+
+use DocSync\Api\Controllers\ProjectController;
+use DocSync\Core\Project;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class NavigationBlock {
+
+	/**
+	 * Register the block with WordPress.
+	 */
+	public static function init(): void {
+		add_action( 'init', [ __CLASS__, 'register' ] );
+	}
+
+	/**
+	 * Register the block type from block.json metadata.
+	 */
+	public static function register(): void {
+		register_block_type( DOCSYNC_PATH . 'blocks/navigation' );
+	}
+
+	/**
+	 * Render the navigation block.
+	 *
+	 * Determines the appropriate mode (TOC or Tree) based on block
+	 * attributes and page context, then delegates to the renderer.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML.
+	 */
+	public static function render( array $attributes ): string {
+		$mode         = $attributes['mode'] ?? 'auto';
+		$project_slug = $attributes['projectSlug'] ?? '';
+
+		$resolved_mode = self::resolve_mode( $mode );
+
+		if ( $resolved_mode === 'toc' ) {
+			return self::render_toc();
+		}
+
+		return self::render_tree( $project_slug );
+	}
+
+	/**
+	 * Resolve the rendering mode from attributes and page context.
+	 *
+	 * @param string $mode Block mode attribute: auto, toc, or tree.
+	 * @return string Resolved mode: toc or tree.
+	 */
+	private static function resolve_mode( string $mode ): string {
+		if ( $mode === 'toc' ) {
+			return 'toc';
+		}
+
+		if ( $mode === 'tree' ) {
+			return 'tree';
+		}
+
+		// Auto-detect: single doc → TOC, everything else → tree.
+		if ( is_singular( 'documentation' ) ) {
+			return 'toc';
+		}
+
+		return 'tree';
+	}
+
+	/**
+	 * Render the Table of Contents for the current post.
+	 *
+	 * Extracts h2/h3 headings from the post content and builds
+	 * a linked list with scroll-spy support via docsync-toc.js.
+	 *
+	 * Processes headings in two steps:
+	 * 1. Renders blocks to HTML via do_blocks()
+	 * 2. Generates IDs for headings that lack them (matching ensure_heading_ids)
+	 *
+	 * @return string TOC HTML or empty string if no headings.
+	 */
+	private static function render_toc(): string {
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return '';
+		}
+
+		$content = get_post_field( 'post_content', $post_id );
+		if ( empty( $content ) ) {
+			return '';
+		}
+
+		// Render blocks to HTML, then apply any custom TOC filters.
+		$rendered = apply_filters( 'docsync_toc_content', do_blocks( $content ) );
+
+		// Extract all h2 and h3 headings (with or without IDs).
+		preg_match_all(
+			'/<(h[23])([^>]*)>(.*?)<\/\1>/i',
+			$rendered,
+			$raw_matches,
+			PREG_SET_ORDER
+		);
+
+		if ( empty( $raw_matches ) ) {
+			return '';
+		}
+
+		// Build headers array, generating IDs for headings that lack them.
+		// This mirrors TableOfContents::ensure_heading_ids() which runs on
+		// the_content to add IDs to the actual rendered page.
+		$headers = [];
+		foreach ( $raw_matches as $match ) {
+			$attrs = $match[2];
+			$text  = wp_strip_all_tags( $match[3] );
+
+			// Extract existing ID or generate one.
+			if ( preg_match( '/id=["\']([^"\']+)["\']/', $attrs, $id_match ) ) {
+				$id = $id_match[1];
+			} else {
+				$id = sanitize_title( $text );
+			}
+
+			if ( empty( $id ) || empty( $text ) ) {
+				continue;
+			}
+
+			$headers[] = [
+				'level' => $match[1],
+				'id'    => $id,
+				'text'  => $text,
+			];
+		}
+
+		// Enqueue TOC assets.
+		self::enqueue_toc_assets();
+
+		ob_start();
+		?>
+		<nav class="docsync-toc" aria-label="<?php esc_attr_e( 'Table of Contents', 'docsync' ); ?>">
+			<h3 class="docsync-toc-title"><span><?php esc_html_e( 'On This Page', 'docsync' ); ?></span></h3>
+			<?php echo self::build_toc_list( $headers ); ?>
+		</nav>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Build the TOC list HTML from headers array.
+	 *
+	 * @param array $headers Array of header data with level, id, text.
+	 * @return string HTML list.
+	 */
+	private static function build_toc_list( array $headers ): string {
+		$html = '<ul class="docsync-toc-list">';
+
+		foreach ( $headers as $header ) {
+			$indent_class = $header['level'] === 'h3' ? ' docsync-toc-nested' : '';
+			$html .= sprintf(
+				'<li class="docsync-toc-item%s"><a href="#%s" class="docsync-toc-link">%s</a></li>',
+				$indent_class,
+				esc_attr( $header['id'] ),
+				esc_html( $header['text'] )
+			);
+		}
+
+		$html .= '</ul>';
+
+		return $html;
+	}
+
+	/**
+	 * Render the project tree navigation.
+	 *
+	 * Shows the full hierarchical documentation tree for a project.
+	 * On single doc pages, highlights the current page and auto-expands
+	 * the containing section.
+	 *
+	 * @param string $project_slug Explicit project slug, or empty for auto-detect.
+	 * @return string Tree HTML or empty string.
+	 */
+	private static function render_tree( string $project_slug = '' ): string {
+		$project_term = self::resolve_project_term( $project_slug );
+		if ( ! $project_term ) {
+			return '';
+		}
+
+		$tree = ProjectController::build_doc_tree( $project_term->term_id );
+		if ( empty( $tree ) ) {
+			return '';
+		}
+
+		$post_id     = get_the_ID() ?: 0;
+		$project_url = get_term_link( $project_term );
+
+		// Enqueue tree assets.
+		self::enqueue_tree_assets();
+
+		ob_start();
+		?>
+		<nav class="docsync-project-tree" aria-label="<?php echo esc_attr( sprintf( __( '%s documentation', 'docsync' ), $project_term->name ) ); ?>">
+			<h3 class="docsync-tree-title">
+				<a href="<?php echo esc_url( $project_url ); ?>"><?php echo esc_html( $project_term->name ); ?></a>
+			</h3>
+			<?php echo self::render_tree_sections( $tree, $post_id ); ?>
+		</nav>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Resolve a project term from slug or page context.
+	 *
+	 * @param string $slug Explicit slug or empty for auto-detect.
+	 * @return \WP_Term|null Project term or null.
+	 */
+	private static function resolve_project_term( string $slug ): ?\WP_Term {
+		// Explicit slug provided.
+		if ( ! empty( $slug ) ) {
+			$term = get_term_by( 'slug', $slug, Project::TAXONOMY );
+			return ( $term && ! is_wp_error( $term ) ) ? $term : null;
+		}
+
+		// Auto-detect from current single doc.
+		if ( is_singular( 'documentation' ) ) {
+			$post_id = get_the_ID();
+			if ( $post_id ) {
+				$terms = get_the_terms( $post_id, Project::TAXONOMY );
+				if ( $terms && ! is_wp_error( $terms ) ) {
+					return Project::get_top_level_term( $terms );
+				}
+			}
+		}
+
+		// Auto-detect from taxonomy archive.
+		$queried = get_queried_object();
+		if ( $queried instanceof \WP_Term && $queried->taxonomy === Project::TAXONOMY ) {
+			return Project::get_top_level_term( [ $queried ] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Render tree sections recursively.
+	 *
+	 * @param array $sections Tree sections from ProjectController::build_doc_tree().
+	 * @param int   $post_id  Current post ID for highlighting.
+	 * @return string HTML.
+	 */
+	private static function render_tree_sections( array $sections, int $post_id ): string {
+		$html = '<ul class="docsync-tree-list">';
+
+		foreach ( $sections as $section ) {
+			$term     = $section['term'] ?? null;
+			$docs     = $section['docs'] ?? [];
+			$children = $section['children'] ?? [];
+
+			if ( $term ) {
+				$has_children = ! empty( $docs ) || ! empty( $children );
+				$is_expanded  = $has_children && self::section_contains_post( $section, $post_id );
+				$state_class  = $is_expanded ? 'docsync-tree-expanded' : 'docsync-tree-collapsed';
+
+				$html .= '<li class="docsync-tree-section ' . $state_class . '">';
+				$html .= '<button class="docsync-tree-toggle" aria-expanded="' . ( $is_expanded ? 'true' : 'false' ) . '">';
+				$html .= '<span class="docsync-tree-icon"></span>';
+				$html .= esc_html( $term['name'] );
+				$html .= '</button>';
+
+				if ( $has_children ) {
+					$html .= '<ul class="docsync-tree-children">';
+
+					foreach ( $docs as $doc ) {
+						$html .= self::render_doc_item( $doc, $post_id );
+					}
+
+					if ( ! empty( $children ) ) {
+						foreach ( $children as $child_section ) {
+							$child_term     = $child_section['term'] ?? null;
+							$child_docs     = $child_section['docs'] ?? [];
+							$child_children = $child_section['children'] ?? [];
+
+							if ( $child_term ) {
+								$child_expanded = self::section_contains_post( $child_section, $post_id );
+								$child_state    = $child_expanded ? 'docsync-tree-expanded' : 'docsync-tree-collapsed';
+
+								$html .= '<li class="docsync-tree-section ' . $child_state . '">';
+								$html .= '<button class="docsync-tree-toggle" aria-expanded="' . ( $child_expanded ? 'true' : 'false' ) . '">';
+								$html .= '<span class="docsync-tree-icon"></span>';
+								$html .= esc_html( $child_term['name'] );
+								$html .= '</button>';
+
+								$html .= '<ul class="docsync-tree-children">';
+								foreach ( $child_docs as $doc ) {
+									$html .= self::render_doc_item( $doc, $post_id );
+								}
+								$html .= '</ul></li>';
+							} else {
+								foreach ( $child_docs as $doc ) {
+									$html .= self::render_doc_item( $doc, $post_id );
+								}
+							}
+						}
+					}
+
+					$html .= '</ul>';
+				}
+
+				$html .= '</li>';
+			} else {
+				foreach ( $docs as $doc ) {
+					$html .= self::render_doc_item( $doc, $post_id );
+				}
+			}
+		}
+
+		$html .= '</ul>';
+
+		return $html;
+	}
+
+	/**
+	 * Render a single doc item.
+	 *
+	 * @param array $doc     Doc data with id, title, slug, url.
+	 * @param int   $post_id Current post ID.
+	 * @return string HTML list item.
+	 */
+	private static function render_doc_item( array $doc, int $post_id ): string {
+		$is_current = ( (int) $doc['id'] === $post_id );
+		$classes    = 'docsync-tree-doc';
+
+		if ( $is_current ) {
+			$classes .= ' docsync-tree-current';
+		}
+
+		return sprintf(
+			'<li class="%s"><a href="%s"%s>%s</a></li>',
+			esc_attr( $classes ),
+			esc_url( $doc['url'] ),
+			$is_current ? ' aria-current="page"' : '',
+			esc_html( $doc['title'] )
+		);
+	}
+
+	/**
+	 * Check if a section contains the given post ID.
+	 *
+	 * @param array $section Section data.
+	 * @param int   $post_id Post ID to find.
+	 * @return bool
+	 */
+	private static function section_contains_post( array $section, int $post_id ): bool {
+		foreach ( $section['docs'] ?? [] as $doc ) {
+			if ( (int) $doc['id'] === $post_id ) {
+				return true;
+			}
+		}
+
+		foreach ( $section['children'] ?? [] as $child ) {
+			if ( self::section_contains_post( $child, $post_id ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Enqueue TOC assets when the block renders in TOC mode.
+	 */
+	private static function enqueue_toc_assets(): void {
+		$css_path = DOCSYNC_PATH . 'assets/css/toc.css';
+		$js_path  = DOCSYNC_PATH . 'assets/js/docsync-toc.js';
+
+		if ( file_exists( $css_path ) ) {
+			wp_enqueue_style(
+				'docsync-toc',
+				DOCSYNC_URL . 'assets/css/toc.css',
+				[ 'docsync-tokens' ],
+				filemtime( $css_path )
+			);
+		}
+
+		if ( file_exists( $js_path ) ) {
+			wp_enqueue_script(
+				'docsync-toc',
+				DOCSYNC_URL . 'assets/js/docsync-toc.js',
+				[],
+				filemtime( $js_path ),
+				true
+			);
+		}
+	}
+
+	/**
+	 * Enqueue project tree assets when the block renders in tree mode.
+	 */
+	private static function enqueue_tree_assets(): void {
+		$css_path = DOCSYNC_PATH . 'assets/css/project-tree.css';
+		$js_path  = DOCSYNC_PATH . 'assets/js/docsync-project-tree.js';
+
+		if ( file_exists( $css_path ) ) {
+			wp_enqueue_style(
+				'docsync-project-tree',
+				DOCSYNC_URL . 'assets/css/project-tree.css',
+				[ 'docsync-tokens' ],
+				filemtime( $css_path )
+			);
+		}
+
+		if ( file_exists( $js_path ) ) {
+			wp_enqueue_script(
+				'docsync-project-tree',
+				DOCSYNC_URL . 'assets/js/docsync-project-tree.js',
+				[],
+				filemtime( $js_path ),
+				true
+			);
+		}
+	}
+}

--- a/inc/Blocks/render-navigation.php
+++ b/inc/Blocks/render-navigation.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * DocSync Navigation Block — Server-Side Render
+ *
+ * Context-aware rendering: detects whether we're on a single doc page
+ * or an archive and renders the appropriate navigation mode.
+ *
+ * Modes:
+ * - auto: TOC on single documentation, Tree on archives (default)
+ * - toc:  Always render Table of Contents
+ * - tree: Always render Project Tree
+ *
+ * @package DocSync\Blocks
+ * @since 1.1.0
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block inner content (empty for dynamic blocks).
+ * @var WP_Block $block      Block instance.
+ */
+
+use DocSync\Blocks\NavigationBlock;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+echo NavigationBlock::render( $attributes );

--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -154,6 +154,10 @@ class Assets {
 
 	/**
 	 * Enqueue assets for single documentation pages.
+	 *
+	 * Navigation sidebar assets (project tree, TOC) are now enqueued
+	 * by the docsync/navigation block itself when it renders.
+	 * This method only handles layout and related posts styles.
 	 */
 	private static function enqueue_single_assets() {
 		if ( ! is_singular( 'documentation' ) ) {
@@ -168,8 +172,6 @@ class Assets {
 		);
 
 		self::enqueue_layout_assets();
-		self::enqueue_project_tree_assets();
-		self::enqueue_toc_assets();
 	}
 
 	/**
@@ -181,46 +183,6 @@ class Assets {
 			DOCSYNC_URL . 'assets/css/layout.css',
 			[ 'docsync-tokens' ],
 			filemtime( DOCSYNC_PATH . 'assets/css/layout.css' )
-		);
-	}
-
-	/**
-	 * Enqueue project tree sidebar assets.
-	 */
-	private static function enqueue_project_tree_assets() {
-		wp_enqueue_style(
-			'docsync-project-tree',
-			DOCSYNC_URL . 'assets/css/project-tree.css',
-			[ 'docsync-tokens' ],
-			filemtime( DOCSYNC_PATH . 'assets/css/project-tree.css' )
-		);
-
-		wp_enqueue_script(
-			'docsync-project-tree',
-			DOCSYNC_URL . 'assets/js/docsync-project-tree.js',
-			[],
-			filemtime( DOCSYNC_PATH . 'assets/js/docsync-project-tree.js' ),
-			true
-		);
-	}
-
-	/**
-	 * Enqueue Table of Contents sidebar assets.
-	 */
-	private static function enqueue_toc_assets() {
-		wp_enqueue_style(
-			'docsync-toc',
-			DOCSYNC_URL . 'assets/css/toc.css',
-			[ 'docsync-tokens' ],
-			filemtime( DOCSYNC_PATH . 'assets/css/toc.css' )
-		);
-
-		wp_enqueue_script(
-			'docsync-toc',
-			DOCSYNC_URL . 'assets/js/docsync-toc.js',
-			[],
-			filemtime( DOCSYNC_PATH . 'assets/js/docsync-toc.js' ),
-			true
 		);
 	}
 }

--- a/inc/Templates/DocumentationLayout.php
+++ b/inc/Templates/DocumentationLayout.php
@@ -3,12 +3,8 @@
  * Documentation Layout
  *
  * Wraps single documentation content in a two-column layout with a sidebar.
- * The sidebar collects its content from the docsync_single_sidebar filter,
- * which is where ProjectTree and TableOfContents hook in.
- *
- * This component solves the rendering gap: previously, sidebar components
- * hooked into the filter but nothing applied it. Now the layout wrapper
- * applies the filter and renders the sidebar alongside the content.
+ * The sidebar renders the docsync/navigation block via do_blocks(), which
+ * auto-detects context and shows a table of contents on single doc pages.
  *
  * @package DocSync\Templates
  * @since 1.0.0
@@ -35,9 +31,9 @@ class DocumentationLayout {
 	/**
 	 * Wrap single documentation content with sidebar layout.
 	 *
-	 * Only acts on singular documentation pages. Collects sidebar content
-	 * from the docsync_single_sidebar filter and wraps everything in a
-	 * CSS Grid layout.
+	 * Renders the docsync/navigation block in the sidebar via do_blocks().
+	 * The block auto-detects that we're on a single doc page and renders
+	 * the table of contents.
 	 *
 	 * @param string $content The post content.
 	 * @return string Wrapped content with sidebar, or original content.
@@ -52,17 +48,8 @@ class DocumentationLayout {
 			return $content;
 		}
 
-		/**
-		 * Filter the sidebar content for single documentation pages.
-		 *
-		 * Components hook into this to add sidebar widgets:
-		 * - ProjectTree at priority 5 (project navigation)
-		 * - TableOfContents at priority 10 (page headings)
-		 *
-		 * @param string $sidebar_content Accumulated sidebar HTML.
-		 * @param int    $post_id         Current documentation post ID.
-		 */
-		$sidebar = apply_filters( 'docsync_single_sidebar', '', $post_id );
+		// Render the navigation block — it auto-detects single doc context.
+		$sidebar = do_blocks( '<!-- wp:docsync/navigation {"mode":"auto"} /-->' );
 
 		if ( empty( trim( $sidebar ) ) ) {
 			return $content;

--- a/inc/Templates/TableOfContents.php
+++ b/inc/Templates/TableOfContents.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * Table of Contents Sidebar
+ * Table of Contents — Heading ID Injection
  *
- * Generates a sticky TOC from post content headings for single
- * documentation pages. Includes scroll-spy via docsync-toc.js.
+ * Ensures all h2 and h3 elements in documentation content have IDs
+ * so the docsync/navigation block can link to them in TOC mode.
  *
- * Ported from extrachill-docs with enhancements for nested heading support.
+ * The TOC rendering itself has moved to the NavigationBlock. This class
+ * now only provides the heading ID injection content filter.
  *
  * @package DocSync\Templates
  * @since 1.0.0
@@ -20,88 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TableOfContents {
 
 	/**
-	 * Initialize TOC hooks.
+	 * Initialize heading ID injection.
 	 *
-	 * Hooks into docsync_single_sidebar filter to provide sidebar content.
-	 * Also adds heading IDs to post content if not present.
+	 * Adds id attributes to h2/h3 elements that don't have one,
+	 * so the navigation block's TOC mode can link to them.
 	 */
 	public static function init(): void {
-		add_filter( 'docsync_single_sidebar', [ __CLASS__, 'render' ], 10, 2 );
 		add_filter( 'the_content', [ __CLASS__, 'ensure_heading_ids' ], 5 );
-	}
-
-	/**
-	 * Render TOC sidebar HTML for a documentation post.
-	 *
-	 * @param string $sidebar_content Existing sidebar content.
-	 * @param int    $post_id         Current post ID.
-	 * @return string TOC HTML or existing content if no headings found.
-	 */
-	public static function render( string $sidebar_content, int $post_id ): string {
-		$content = get_post_field( 'post_content', $post_id );
-
-		if ( empty( $content ) ) {
-			return $sidebar_content;
-		}
-
-		// Apply content filters to get rendered HTML (blocks → HTML).
-		$rendered = apply_filters( 'docsync_toc_content', $content );
-
-		// Extract h2 and h3 headings with IDs.
-		preg_match_all(
-			'/<(h[23])[^>]*id=["\']([^"\']+)["\'][^>]*>(.*?)<\/\1>/i',
-			$rendered,
-			$matches,
-			PREG_SET_ORDER
-		);
-
-		if ( empty( $matches ) ) {
-			return $sidebar_content;
-		}
-
-		$headers = [];
-		foreach ( $matches as $match ) {
-			$headers[] = [
-				'level' => $match[1],
-				'id'    => $match[2],
-				'text'  => wp_strip_all_tags( $match[3] ),
-			];
-		}
-
-		ob_start();
-		?>
-		<nav class="docsync-toc" aria-label="<?php esc_attr_e( 'Table of Contents', 'docsync' ); ?>">
-			<h3 class="docsync-toc-title"><span><?php esc_html_e( 'On This Page', 'docsync' ); ?></span></h3>
-			<?php echo self::build_list( $headers ); ?>
-		</nav>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Build the TOC list HTML from headers array.
-	 *
-	 * Supports nested h2 → h3 hierarchy.
-	 *
-	 * @param array $headers Array of header data with level, id, text.
-	 * @return string HTML list.
-	 */
-	private static function build_list( array $headers ): string {
-		$html = '<ul class="docsync-toc-list">';
-
-		foreach ( $headers as $header ) {
-			$indent_class = $header['level'] === 'h3' ? ' docsync-toc-nested' : '';
-			$html .= sprintf(
-				'<li class="docsync-toc-item%s"><a href="#%s" class="docsync-toc-link">%s</a></li>',
-				$indent_class,
-				esc_attr( $header['id'] ),
-				esc_html( $header['text'] )
-			);
-		}
-
-		$html .= '</ul>';
-
-		return $html;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Introduces a **context-aware `docsync/navigation` Gutenberg block** that replaces the old filter-based sidebar system
- Single doc pages show a **Table of Contents** (h2/h3 heading links with scroll-spy)
- Archive/landing pages show the **full project tree** (hierarchical navigation)
- One block, two modes — auto-detects from page context, or manually override with `mode` attribute (`auto`/`toc`/`tree`)

## What Changed

**New files:**
- `blocks/navigation/block.json` — block metadata with mode and projectSlug attributes
- `blocks/navigation/index.js` — editor component with settings panel
- `inc/Blocks/NavigationBlock.php` — render callback with TOC/tree logic merged in
- `inc/Blocks/render-navigation.php` — block render template

**Modified files:**
- `docsync.php` — registers NavigationBlock, removes ProjectTree/TOC filter hooks
- `DocumentationLayout.php` — uses `do_blocks()` instead of `docsync_single_sidebar` filter
- `TableOfContents.php` — reduced to heading ID injection only (render logic moved to block)
- `Assets.php` — no longer globally enqueues tree/TOC assets (block self-enqueues)

## Why

The old sidebar rendered a full project tree on every single doc page — irrelevant to the page being read. The TOC was also broken (overwriting ProjectTree output instead of appending). This refactor makes the sidebar contextual and gives editors a reusable block they can place anywhere.

## Testing

- Verified TOC renders on single doc pages with headings
- Verified tree renders with explicit `projectSlug` attribute
- Verified no project-tree assets load on single doc pages (only TOC CSS/JS)
- Verified pages without headings gracefully skip the sidebar
- Live on chubes.net for visual testing