### PR TITLE
Batch sync notifications into a single daily digest email

### DIFF
--- a/docsync.php
+++ b/docsync.php
@@ -3,7 +3,7 @@
  * Plugin Name: DocSync
  * Plugin URI: https://github.com/chubes4/docsync
  * Description: GitHub-to-WordPress documentation sync system with REST API, WP-CLI, and hierarchical project organization.
- * Version: 1.1.1
+ * Version: 1.2.0
  * Author: Chris Huber
  * Author URI: https://chubes.net
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'DOCSYNC_VERSION', '1.1.1' );
+define( 'DOCSYNC_VERSION', '1.2.0' );
 define( 'DOCSYNC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DOCSYNC_URL', plugin_dir_url( __FILE__ ) );
 
@@ -41,6 +41,7 @@ use DocSync\Templates\Homepage;
 use DocSync\Templates\SearchBar;
 use DocSync\Templates\TableOfContents;
 use DocSync\Sync\CronSync;
+use DocSync\Sync\SyncNotifier;
 use DocSync\Admin\SettingsPage;
 use DocSync\Admin\ProjectColumns;
 use DocSync\Admin\DocumentationColumns;
@@ -57,6 +58,7 @@ add_action( 'docsync_project_registered', function() {
 } );
 
 CronSync::init();
+SyncNotifier::init();
 SettingsPage::init();
 DocumentationColumns::init();
 

--- a/inc/Sync/SyncNotifier.php
+++ b/inc/Sync/SyncNotifier.php
@@ -2,8 +2,9 @@
 /**
  * Sync Email Notifier
  *
- * Sends email notifications to the site admin when documentation
- * is synced and changes occur.
+ * Queues documentation sync results and sends a single batched digest
+ * email to the site admin once per day (via the docsync_digest_send cron),
+ * instead of one email per project sync.
  */
 
 namespace DocSync\Sync;
@@ -13,12 +14,67 @@ use DocSync\Core\Project;
 class SyncNotifier {
 
 	/**
-	 * Send sync report email if changes occurred.
+	 * Option key for the pending digest queue.
+	 *
+	 * Stored as an array keyed by term ID. The latest result for a given
+	 * term within the digest window overwrites the previous one.
+	 */
+	const OPTION_QUEUE = 'docsync_digest_queue';
+
+	/**
+	 * Cron hook that flushes the queue into a single digest email.
+	 */
+	const CRON_HOOK = 'docsync_digest_send';
+
+	/**
+	 * Register the daily digest cron.
+	 */
+	public static function init(): void {
+		add_action( self::CRON_HOOK, [ __CLASS__, 'send_digest' ] );
+		add_action( 'admin_init', [ __CLASS__, 'schedule' ] );
+		register_deactivation_hook( DOCSYNC_PATH . 'docsync.php', [ __CLASS__, 'unschedule' ] );
+	}
+
+	/**
+	 * Schedule the daily digest event if not already scheduled.
+	 */
+	public static function schedule(): void {
+		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+			return;
+		}
+		wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+	}
+
+	/**
+	 * Unschedule the digest event.
+	 */
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Queue a sync result for the next daily digest.
+	 *
+	 * Replaces the previous per-sync immediate email. Kept named send()
+	 * so existing call sites continue to work unchanged.
 	 *
 	 * @param int   $term_id Project term ID.
 	 * @param array $results Sync results from RepoSync.
 	 */
 	public function send( int $term_id, array $results ): void {
+		$this->queue( $term_id, $results );
+	}
+
+	/**
+	 * Add a sync result to the pending digest queue.
+	 *
+	 * @param int   $term_id Project term ID.
+	 * @param array $results Sync results from RepoSync.
+	 */
+	public function queue( int $term_id, array $results ): void {
 		if ( ! $this->has_changes( $results ) ) {
 			return;
 		}
@@ -28,9 +84,65 @@ class SyncNotifier {
 			return;
 		}
 
-		$to = get_option( 'admin_email' );
-		$subject = $this->build_subject( $term->name, $results['success'] ? 'Success' : 'Failed' );
-		$body = $this->build_body( $term, $results );
+		$queue = get_option( self::OPTION_QUEUE, [] );
+		if ( ! is_array( $queue ) ) {
+			$queue = [];
+		}
+
+		$queue[ $term_id ] = [
+			'results'  => $results,
+			'queued_at' => time(),
+		];
+
+		update_option( self::OPTION_QUEUE, $queue, false );
+	}
+
+	/**
+	 * Flush the queue: send one digest email covering all queued projects,
+	 * then clear the queue. Invoked by the daily cron.
+	 */
+	public static function send_digest(): void {
+		$notifier = new self();
+		$notifier->flush();
+	}
+
+	/**
+	 * Build and send the digest email from the current queue, then clear it.
+	 */
+	public function flush(): void {
+		$queue = get_option( self::OPTION_QUEUE, [] );
+		if ( empty( $queue ) || ! is_array( $queue ) ) {
+			return;
+		}
+
+		$sections   = [];
+		$project_names = [];
+
+		foreach ( $queue as $term_id => $entry ) {
+			$results = $entry['results'] ?? null;
+			if ( empty( $results ) ) {
+				continue;
+			}
+
+			$term = get_term( (int) $term_id, Project::TAXONOMY );
+			if ( ! $term || is_wp_error( $term ) ) {
+				continue;
+			}
+
+			$project_names[] = $term->name;
+			$sections[]      = $this->build_project_section( $term, $results );
+		}
+
+		// Always clear the queue, even if every entry was stale/invalid.
+		delete_option( self::OPTION_QUEUE );
+
+		if ( empty( $sections ) ) {
+			return;
+		}
+
+		$to      = get_option( 'admin_email' );
+		$subject = $this->build_subject( count( $sections ) );
+		$body    = $this->build_digest_body( $sections, $project_names );
 		$headers = [ 'Content-Type: text/plain; charset=UTF-8' ];
 
 		wp_mail( $to, $subject, $body, $headers );
@@ -50,30 +162,46 @@ class SyncNotifier {
 	}
 
 	/**
-	 * Build email subject line.
+	 * Build the digest email subject line.
 	 *
-	 * @param string $project_name Project name.
-	 * @param string $status       Status: 'Success' or 'Failed'.
+	 * @param int $project_count Number of projects in the digest.
 	 * @return string Email subject.
 	 */
-	private function build_subject( string $project_name, string $status ): string {
+	private function build_subject( int $project_count ): string {
 		$site_name = get_bloginfo( 'name' );
-		return sprintf( '[%s] Docs Sync: %s - %s', $site_name, $project_name, $status );
+		$noun      = 1 === $project_count ? 'project' : 'projects';
+		return sprintf( '[%s] Docs Sync Digest: %d %s updated', $site_name, $project_count, $noun );
 	}
 
 	/**
-	 * Build email body.
+	 * Build the full digest body from per-project sections.
+	 *
+	 * @param string[] $sections      Rendered per-project sections.
+	 * @param string[] $project_names Project names included in the digest.
+	 * @return string Email body.
+	 */
+	private function build_digest_body( array $sections, array $project_names ): string {
+		$lines = [];
+
+		$lines[] = 'Documentation Sync Digest';
+		$lines[] = str_repeat( '=', 40 );
+		$lines[] = 'Time: ' . wp_date( 'M j, Y \a\t g:ia' );
+		$lines[] = sprintf( 'Projects updated (%d): %s', count( $project_names ), implode( ', ', $project_names ) );
+		$lines[] = '';
+		$lines[] = implode( "\n\n" . str_repeat( '=', 40 ) . "\n\n", $sections );
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Build the report section for a single project.
 	 *
 	 * @param \WP_Term $term    Project term.
 	 * @param array    $results Sync results.
-	 * @return string Email body.
+	 * @return string Project section text.
 	 */
-	private function build_body( \WP_Term $term, array $results ): string {
+	private function build_project_section( \WP_Term $term, array $results ): string {
 		$lines = [];
-
-		$lines[] = 'Documentation Sync Report';
-		$lines[] = str_repeat( '-', 40 );
-		$lines[] = '';
 
 		$project_line = 'Project: ' . $term->name;
 		$installs = $this->get_install_count( $term->term_id );
@@ -88,13 +216,12 @@ class SyncNotifier {
 		}
 
 		$lines[] = 'Status: ' . ( $results['success'] ? 'Success' : 'Failed' );
-		$lines[] = 'Time: ' . wp_date( 'M j, Y \a\t g:ia' );
 
-		if ( $results['old_sha'] && $results['new_sha'] ) {
+		if ( ! empty( $results['old_sha'] ) && ! empty( $results['new_sha'] ) ) {
 			$old_short = substr( $results['old_sha'], 0, 7 );
 			$new_short = substr( $results['new_sha'], 0, 7 );
 			$lines[] = "Commit: {$old_short} -> {$new_short}";
-		} elseif ( $results['new_sha'] ) {
+		} elseif ( ! empty( $results['new_sha'] ) ) {
 			$new_short = substr( $results['new_sha'], 0, 7 );
 			$lines[] = "Commit: {$new_short} (initial sync)";
 		}
@@ -138,13 +265,12 @@ class SyncNotifier {
 			$lines[] = '';
 		}
 
-		$lines[] = str_repeat( '-', 40 );
 		$docs_url = $this->get_docs_url( $term );
 		if ( $docs_url ) {
 			$lines[] = 'View documentation: ' . $docs_url;
 		}
 
-		return implode( "\n", $lines );
+		return rtrim( implode( "\n", $lines ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- DocSync previously sent **one email per project** on every sync run — flooding the admin inbox during scheduled `twicedaily` syncs.
- `SyncNotifier` now **queues** each project's result into the `docsync_digest_queue` option instead of emailing immediately.
- A new **daily cron** (`docsync_digest_send`) flushes the queue into **one combined digest email** covering all updated projects, then clears it.

## How it works
- `send()` is preserved but now delegates to `queue()`, so all three existing call sites work unchanged:
  - `CronSync::run()`
  - `CronSync::sync_term()`
  - `SyncAbilities::sync_callback()`
- The per-project report body was refactored into `build_project_section()`, a reusable section. The digest lists every updated project under a single header.
- Queue is keyed by term ID — repeated syncs of the same project within a day collapse to the latest result.
- `SyncNotifier::init()` registers the daily cron and unschedules it on deactivation.

## Notes
- No new settings/options UI required; recipient is still `admin_email`.
- The admin "Sync All Now" button + ability still return an on-screen summary immediately; only the email is deferred to the daily digest.
- Version bumped to **1.2.0**.

## Test plan
- [ ] Trigger a sync with changes → confirm no immediate email, queue option populated
- [ ] Run `docsync_digest_send` cron (or `wp cron event run docsync_digest_send`) → confirm one digest email with all projects, queue cleared
- [ ] Confirm no email is sent when queue is empty