### PR TITLE
Enrich homeboy.json for deploy pipeline + 1.2.0 changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-06-15
+
+### Changed
+- Batch sync notifications into a single daily digest email instead of one email per project. Sync results are queued (`docsync_digest_queue`) and a new daily cron (`docsync_digest_send`) sends one combined report covering all updated projects, then clears the queue.
+
 ## [1.1.1] - 2026-03-01
 
 ### Fixed

--- a/homeboy.json
+++ b/homeboy.json
@@ -1,5 +1,21 @@
 {
+  "auto_cleanup": false,
+  "changelog_target": "docs/CHANGELOG.md",
+  "extensions": {
+    "wordpress": {}
+  },
   "id": "docsync",
   "name": "DocSync",
-  "source_path": "."
+  "remote_path": "wp-content/plugins/docsync",
+  "source_path": ".",
+  "version_targets": [
+    {
+      "file": "docsync.php",
+      "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "docsync.php",
+      "pattern": "(?m)DOCSYNC_VERSION',\\s*'([0-9.]+)'"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enriches `homeboy.json` so DocSync becomes a fully deployable homeboy component on `chubes-site` (mirrors the `intelligence`/`chubes` config).
- Adds `changelog_target`, `extensions.wordpress` (provides the WP build/artifact pattern), `remote_path`, and `version_targets`.
- Backfills the **1.2.0** changelog entry for the daily-digest email batching shipped in #55.

## Why
Previously `homeboy deploy chubes-site docsync` skipped docsync with *"no build artifact or deploy strategy"* because its `homeboy.json` was minimal (`id`/`name`/`source_path` only). The WordPress extension resolves the build artifact, but only when declared in `homeboy.json` — which `homeboy project components attach-path` reads as the source of truth.

## Result
After merge + `attach-path`, deploys are one command:
```
homeboy deploy chubes-site docsync
```