### PR TITLE
fix: reset sync status to success on no-changes early return

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-07-13
+
+### Fixed
+- Reset project sync status to `success` when a repo has no changes. Previously the no-changes early return left `project_sync_status` stuck on `syncing` indefinitely for up-to-date projects, even though the sync completed successfully. ([#57](https://github.com/chubes4/docsync/issues/57))
+
 ## [1.2.0] - 2026-06-15
 
 ### Changed

--- a/docsync.php
+++ b/docsync.php
@@ -3,7 +3,7 @@
  * Plugin Name: DocSync
  * Plugin URI: https://github.com/chubes4/docsync
  * Description: GitHub-to-WordPress documentation sync system with REST API, WP-CLI, and hierarchical project organization.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Chris Huber
  * Author URI: https://chubes.net
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'DOCSYNC_VERSION', '1.2.0' );
+define( 'DOCSYNC_VERSION', '1.2.1' );
 define( 'DOCSYNC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DOCSYNC_URL', plugin_dir_url( __FILE__ ) );
 

--- a/inc/Sync/RepoSync.php
+++ b/inc/Sync/RepoSync.php
@@ -91,6 +91,7 @@ class RepoSync {
 		if ( $old_sha === $new_sha ) {
 			$result['success'] = true;
 			$result['error'] = 'No changes detected';
+			$this->update_sync_status( $term_id, 'success' );
 			return $result;
 		}
 


### PR DESCRIPTION
## Summary
- Fixes the `project_sync_status` flag getting stuck on `syncing` for projects that are already up to date.
- `RepoSync::sync()` set status to `syncing` at the top, then returned early on the `$old_sha === $new_sha` (no-changes) path **without** ever setting it back to `success`. Now it calls `update_sync_status( $term_id, 'success' )` before returning, which also clears any stale `project_sync_error`.
- Bumped version to 1.2.1 and added a changelog entry.

## Why
Observed on chubes.net: after repointing several projects to renamed GitHub repos, every `wp docsync docs sync <id>` returned Success with 0 errors, but the terms stayed at `project_sync_status = syncing`. Anything reading that flag (admin columns, health checks) saw a false in-progress state.

## Test plan
1. Sync a project once so `project_last_sync_sha` is stored.
2. Sync again with no upstream commits: `wp docsync docs sync <term_id>`.
3. `wp term meta get <term_id> project_sync_status` → now `success` (was `syncing`).

Closes #57